### PR TITLE
feat: rebuild minimal prompt pipeline

### DIFF
--- a/packages/translation-core/src/llmTranslate.ts
+++ b/packages/translation-core/src/llmTranslate.ts
@@ -32,6 +32,10 @@ import {
   roundtripHtmlForTest,
   sanitizeHtmlTextTranslation,
 } from "./htmlTranslate.js";
+import {
+  buildPromptContextBlock,
+  buildResolvedPromptContext,
+} from "./promptContextBuilder.js";
 import { enforceTranslateResultLimits } from "./translationFieldLimits.js";
 import {
   maskPlaceholders,
@@ -1568,19 +1572,34 @@ function fieldTier(
   return value.length >= SHORT_PLAIN_THRESHOLD ? "rich" : "trivial";
 }
 
-function poolSignature(order: Engine[], isHandle: boolean): string {
+function poolSignature(
+  order: Engine[],
+  isHandle: boolean,
+  promptProfileId?: string,
+): string {
   const base = order.join(",");
-  return isHandle ? `${HANDLE_POOL_PREFIX}${base}` : base;
+  const scoped = promptProfileId ? `${base}::${promptProfileId}` : base;
+  return isHandle ? `${HANDLE_POOL_PREFIX}${scoped}` : scoped;
 }
 
-function parsePoolSignature(sig: string): { order: Engine[]; isHandle: boolean } {
+function parsePoolSignature(
+  sig: string,
+): { order: Engine[]; isHandle: boolean; promptProfileId: string | null } {
   if (sig.startsWith(HANDLE_POOL_PREFIX)) {
+    const raw = sig.slice(HANDLE_POOL_PREFIX.length);
+    const [orderSig, promptProfileId] = raw.split("::", 2);
     return {
       isHandle: true,
-      order: sig.slice(HANDLE_POOL_PREFIX.length).split(",") as Engine[],
+      order: orderSig.split(",") as Engine[],
+      promptProfileId: promptProfileId ?? null,
     };
   }
-  return { isHandle: false, order: sig.split(",") as Engine[] };
+  const [orderSig, promptProfileId] = sig.split("::", 2);
+  return {
+    isHandle: false,
+    order: orderSig.split(",") as Engine[],
+    promptProfileId: promptProfileId ?? null,
+  };
 }
 
 /** Ordered engine candidates for a tier (primary first, then fallback). */
@@ -2174,6 +2193,7 @@ async function translateItemsRouted(
   shopName: string,
   order: Engine[],
   promptKind: "default" | "handle" = "default",
+  promptContextBlock = "",
   customPrompt = "",
   /** 仅管理页单条翻译：把 LLM 原始返回打到日志。 */
   logSingleTranslate = false,
@@ -2202,14 +2222,15 @@ async function translateItemsRouted(
         const glossary = await loadGlossaryLines(shopName, target);
         systemPrompt =
           promptKind === "handle"
-            ? buildHandleSystemPrompt(target, glossary, "", customPrompt)
-            : buildSystemPrompt(target, glossary, "", customPrompt);
+            ? buildHandleSystemPrompt(target, glossary, promptContextBlock, customPrompt)
+            : buildSystemPrompt(target, glossary, promptContextBlock, customPrompt);
         if (logSingleTranslate) {
           console.log("[single] prompt", {
             shopName,
             source,
             target,
             promptKind,
+            promptContextBlock,
             customPrompt,
             prompt: systemPrompt,
           });
@@ -2347,6 +2368,7 @@ async function retryPoolFallbacks(
         shopName,
         poolOrder,
         isHandle ? "handle" : "default",
+        "",
         customPrompt,
         logSingleTranslate,
       );
@@ -2427,7 +2449,7 @@ function buildSystemPrompt(
   const glossaryBlock = glossaryLines.length
     ? `\nGlossary (apply consistently):\n${glossaryLines.join("\n")}\n`
     : "";
-  const shopContextBlock = profileBlock ? `\n${profileBlock}\n` : "";
+  const shopContextBlock = profileBlock ? `\nPrompt context:\n${profileBlock}\n` : "";
   const userInstructionBlock = userInstruction.trim()
     ? `\nAdditional user instructions for this translation (apply to tone, style, and word choice; they MUST NOT override any of the output-format, JSON structure, sentinel, or placeholder rules above):\n${userInstruction.trim()}\n`
     : "";
@@ -2464,7 +2486,7 @@ function buildHandleSystemPrompt(
   const glossaryBlock = glossaryLines.length
     ? `\nGlossary (apply consistently):\n${glossaryLines.join("\n")}\n`
     : "";
-  const shopContextBlock = profileBlock ? `\n${profileBlock}\n` : "";
+  const shopContextBlock = profileBlock ? `\nPrompt context:\n${profileBlock}\n` : "";
   const userInstructionBlock = userInstruction.trim()
     ? `\nAdditional user instructions for this translation (apply to tone, style, and word choice; they MUST NOT override any of the output-format, JSON structure, sentinel, or placeholder rules above):\n${userInstruction.trim()}\n`
     : "";
@@ -2815,6 +2837,8 @@ type FieldPlan = {
   digest: string;
   order: Engine[];
   poolSig: string;
+  promptProfileId: string;
+  promptContextBlock: string;
   cacheModel: string;
 } & (
   | { kind: "plain"; parts: string[]; isHandle?: boolean }
@@ -3129,9 +3153,14 @@ export async function translateResources(
   const plans: FieldPlan[] = [];
   // orderSig → (unique text → occurrence count across the chunk).
   const pools = new Map<string, Map<string, number>>();
-  const addUnit = (order: Engine[], text: string, isHandle = false) => {
+  const addUnit = (
+    order: Engine[],
+    text: string,
+    isHandle = false,
+    promptProfileId?: string,
+  ) => {
     if (!isTranslatableLeafText(text)) return;
-    const sig = poolSignature(order, isHandle);
+    const sig = poolSignature(order, isHandle, promptProfileId);
     const occ = pools.get(sig) ?? pools.set(sig, new Map()).get(sig)!;
     occ.set(text, (occ.get(text) ?? 0) + 1);
   };
@@ -3203,6 +3232,14 @@ export async function translateResources(
   for (let wi = 0; wi < fieldWorks.length; wi++) {
     const { resourceId, f, klass, order, cacheModel } = fieldWorks[wi];
     const rm = resultMaps.get(resourceId)!;
+    const promptContext = buildResolvedPromptContext({
+      module: f.shopifyType ?? null,
+      key: f.key,
+      contentClass: klass === "liquid_html" ? "liquid_html" : (klass as "html" | "json" | "list" | "plain"),
+      shopifyType: f.shopifyType,
+    });
+    const promptProfileId = promptContext.promptProfileId;
+    const promptContextBlock = buildPromptContextBlock(promptContext) ?? "";
     if (!f.value.trim()) {
       logSingleTranslatePath(logSingleTranslate, "skip", {
         reason: "empty_value",
@@ -3282,14 +3319,16 @@ export async function translateResources(
         rm.set(f.key, { key: f.key, translatedValue: f.value, digest: f.digest, status: "translated" });
         continue;
       }
-      nodeParts.forEach((parts) => parts.forEach((p) => addUnit(order, p)));
+      nodeParts.forEach((parts) => parts.forEach((p) => addUnit(order, p, false, promptProfileId)));
       plans.push({
         kind: "html",
         resourceId,
         key: f.key,
         digest: f.digest,
         order,
-        poolSig: poolSignature(order, false),
+        poolSig: poolSignature(order, false, promptProfileId),
+        promptProfileId,
+        promptContextBlock,
         cacheModel,
         template,
         nodeParts,
@@ -3300,14 +3339,16 @@ export async function translateResources(
         rm.set(f.key, { key: f.key, translatedValue: f.value, digest: f.digest, status: "translated" });
         continue;
       }
-      nodeParts.forEach((parts) => parts.forEach((p) => addUnit(order, p)));
+      nodeParts.forEach((parts) => parts.forEach((p) => addUnit(order, p, false, promptProfileId)));
       plans.push({
         kind: "liquid_html",
         resourceId,
         key: f.key,
         digest: f.digest,
         order,
-        poolSig: poolSignature(order, false),
+        poolSig: poolSignature(order, false, promptProfileId),
+        promptProfileId,
+        promptContextBlock,
         cacheModel,
         template,
         nodeParts,
@@ -3317,14 +3358,16 @@ export async function translateResources(
       const root = tryParseJsonContainer(f.value);
       if (root === undefined) {
         const parts = splitPlainText(f.value);
-        parts.forEach((p) => addUnit(order, p));
+        parts.forEach((p) => addUnit(order, p, false, promptProfileId));
         plans.push({
           kind: "plain",
           resourceId,
           key: f.key,
           digest: f.digest,
           order,
-          poolSig: poolSignature(order, false),
+          poolSig: poolSignature(order, false, promptProfileId),
+          promptProfileId,
+          promptContextBlock,
           cacheModel,
           parts,
         });
@@ -3342,10 +3385,10 @@ export async function translateResources(
               slotPlans.push({ ...slot });
               continue;
             }
-            nodeParts.forEach((parts) => parts.forEach((p) => addUnit(order, p)));
+            nodeParts.forEach((parts) => parts.forEach((p) => addUnit(order, p, false, promptProfileId)));
             slotPlans.push({ ...slot, htmlPlan: { template, nodeParts } });
           } else {
-            addUnit(order, slot.text);
+            addUnit(order, slot.text, false, promptProfileId);
             slotPlans.push({ ...slot });
           }
         }
@@ -3355,7 +3398,9 @@ export async function translateResources(
           key: f.key,
           digest: f.digest,
           order,
-          poolSig: poolSignature(order, false),
+          poolSig: poolSignature(order, false, promptProfileId),
+          promptProfileId,
+          promptContextBlock,
           cacheModel,
           originalValue: f.value,
           root,
@@ -3371,10 +3416,10 @@ export async function translateResources(
         if (isHtml(el)) {
           const { template, nodeParts } = htmlNodePartsOf(el);
           if (nodeParts.length === 0) continue;
-          nodeParts.forEach((parts) => parts.forEach((p) => addUnit(order, p)));
+          nodeParts.forEach((parts) => parts.forEach((p) => addUnit(order, p, false, promptProfileId)));
           elements.push({ index: i, text: el, htmlPlan: { template, nodeParts } });
         } else {
-          addUnit(order, el);
+          addUnit(order, el, false, promptProfileId);
           elements.push({ index: i, text: el });
         }
       }
@@ -3388,7 +3433,9 @@ export async function translateResources(
         key: f.key,
         digest: f.digest,
         order,
-        poolSig: poolSignature(order, false),
+        poolSig: poolSignature(order, false, promptProfileId),
+        promptProfileId,
+        promptContextBlock,
         cacheModel,
         originalValue: f.value,
         elements,
@@ -3397,8 +3444,8 @@ export async function translateResources(
       const isHandle = isHandleFieldKey(f.key);
       const sourceText = isHandle ? prepareHandleSourceText(f.value) : f.value;
       const parts = splitPlainText(sourceText);
-      const poolSig = poolSignature(order, isHandle);
-      parts.forEach((p) => addUnit(order, p, isHandle));
+      const poolSig = poolSignature(order, isHandle, promptProfileId);
+      parts.forEach((p) => addUnit(order, p, isHandle, promptProfileId));
       plans.push({
         kind: "plain",
         resourceId,
@@ -3406,6 +3453,8 @@ export async function translateResources(
         digest: f.digest,
         order,
         poolSig,
+        promptProfileId,
+        promptContextBlock,
         cacheModel,
         parts,
         isHandle,
@@ -3477,6 +3526,8 @@ export async function translateResources(
     const cacheModel = engineModel(order[0]!, aiModel);
     const allTexts = [...occ.keys()];
     const tmap = new Map<string, RoutedResult>();
+    const promptContextBlock =
+      plans.find((plan) => plan.poolSig === sig)?.promptContextBlock ?? "";
 
     // 2a. Value-TM prefilter for every unique leaf in this pool.
     if (!skipCacheRead) {
@@ -3525,6 +3576,7 @@ export async function translateResources(
         shopName,
         order,
         isHandle ? "handle" : "default",
+        promptContextBlock,
         customPrompt,
         logSingleTranslate,
       );

--- a/packages/translation-core/src/promptContextBuilder.ts
+++ b/packages/translation-core/src/promptContextBuilder.ts
@@ -1,0 +1,270 @@
+import {
+  getTranslationFieldConstraintHints,
+  getTranslationFieldRule,
+  type TranslationConstraintOrigin,
+  type TranslationFieldRule,
+} from "./translationFieldLimits.js";
+import {
+  resolveTranslationScene,
+  type FieldContentClass,
+  type TranslationAudience,
+  type TranslationPromptProfileId,
+  type TranslationRewriteFreedom,
+  type TranslationRole,
+  type TranslationScene,
+} from "./translationSceneResolver.js";
+
+export type TranslationConstraintSet = {
+  preserveHtmlStructure: boolean;
+  preserveJsonStructure: boolean;
+  preserveSentinels: boolean;
+  preservePlaceholders: boolean;
+  noHtmlTagsInLeaf: boolean;
+  keepLeadingTrailingWhitespace: boolean;
+  maxChars?: number;
+  recommendedMaxChars?: number;
+  mustBeSlugLike?: boolean;
+  shortUiLabelPreferred?: boolean;
+  fieldHints: Array<{
+    code: string;
+    origin: TranslationConstraintOrigin;
+    promptText: string;
+    maxChars?: number;
+  }>;
+};
+
+export type ResolvedTranslationPromptContext = {
+  promptProfileId: TranslationPromptProfileId;
+  scene: TranslationScene;
+  role: TranslationRole | null;
+  module: string | null;
+  contentClass: FieldContentClass;
+  fieldKind: TranslationFieldRule["fieldKind"];
+  audience: TranslationAudience;
+  rewriteFreedom: TranslationRewriteFreedom;
+  constraints: TranslationConstraintSet;
+};
+
+export type TranslationPromptPlan = {
+  task: {
+    scene: TranslationScene;
+    role: TranslationRole | null;
+    fieldKind: TranslationFieldRule["fieldKind"];
+    fieldRule: TranslationFieldRule;
+    audience: TranslationAudience;
+    rewriteFreedom: TranslationRewriteFreedom;
+    contentClass: FieldContentClass;
+    module: string | null;
+  };
+  constraints: TranslationConstraintSet;
+  debugReasons: string[];
+};
+
+type InferredModulePolicy = {
+  summary: string;
+  lines: string[];
+} | null;
+
+export function buildResolvedPromptContext(args: {
+  module?: string | null;
+  key: string;
+  contentClass: FieldContentClass;
+  shopifyType?: string | null;
+}): ResolvedTranslationPromptContext {
+  const resolution = resolveTranslationScene({
+    module: args.module,
+    key: args.key,
+    contentClass: args.contentClass,
+    shopifyType: args.shopifyType,
+  });
+  const fieldRule = getTranslationFieldRule(resolution.fieldKind);
+
+  return {
+    ...resolution,
+    constraints: {
+      preserveHtmlStructure:
+        resolution.contentClass === "html" || resolution.contentClass === "liquid_html",
+      preserveJsonStructure:
+        resolution.contentClass === "json" || resolution.contentClass === "list",
+      preserveSentinels: true,
+      preservePlaceholders: true,
+      noHtmlTagsInLeaf: true,
+      keepLeadingTrailingWhitespace: true,
+      maxChars: fieldRule.maxChars,
+      recommendedMaxChars: fieldRule.recommendedMaxChars,
+      mustBeSlugLike: fieldRule.mustBeSlugLike,
+      shortUiLabelPreferred: fieldRule.shortUiLabelPreferred,
+      fieldHints: getTranslationFieldConstraintHints(fieldRule),
+    },
+  };
+}
+
+export function buildPromptPlan(
+  context: ResolvedTranslationPromptContext,
+): TranslationPromptPlan {
+  const fieldRule = getTranslationFieldRule(context.fieldKind);
+  const debugReasons: string[] = [
+    `profile:${context.promptProfileId}`,
+    `scene:${context.scene}`,
+    `content:${context.contentClass}`,
+  ];
+  for (const hint of context.constraints.fieldHints) {
+    debugReasons.push(`constraint:${hint.code}:${hint.origin}`);
+  }
+  const modulePolicy = inferModulePolicy(context);
+  if (modulePolicy) {
+    debugReasons.push(`module_policy:${sanitizeDebugToken(modulePolicy.summary)}`);
+  }
+
+  return {
+    task: {
+      scene: context.scene,
+      role: context.role,
+      fieldKind: context.fieldKind,
+      fieldRule,
+      audience: context.audience,
+      rewriteFreedom: context.rewriteFreedom,
+      contentClass: context.contentClass,
+      module: context.module,
+    },
+    constraints: context.constraints,
+    debugReasons,
+  };
+}
+
+export function buildPromptContextBlock(
+  context: ResolvedTranslationPromptContext,
+): string | null {
+  const plan = buildPromptPlan(context);
+  const lines: string[] = [];
+  const modulePolicy = inferModulePolicy(context);
+
+  lines.push(
+    `Task profile: ${plan.task.scene.replace(/_/g, " ")} (${plan.task.contentClass.replace(/_/g, " ")})`,
+  );
+
+  if (plan.task.role) {
+    lines.push(`Field role: ${plan.task.role.replace(/_/g, " ")}`);
+  }
+
+  if (plan.task.module) {
+    lines.push(`Module context: ${plan.task.module}`);
+  }
+
+  if (plan.task.audience === "merchant") {
+    lines.push("Audience: merchant admin UI copy. Keep wording clear and compact.");
+  } else if (plan.task.audience === "system") {
+    lines.push("Audience: system-facing value. Preserve stability over flourish.");
+  } else {
+    lines.push("Audience: storefront shoppers. Keep wording natural and conversion-safe.");
+  }
+
+  if (plan.task.rewriteFreedom === "strict") {
+    lines.push("Rewrite freedom: strict. Preserve intent and shape very closely.");
+  } else if (plan.task.rewriteFreedom === "balanced") {
+    lines.push("Rewrite freedom: balanced. Improve clarity, but stay compact and faithful.");
+  } else {
+    lines.push("Rewrite freedom: adaptive. Natural e-commerce phrasing is allowed.");
+  }
+
+  for (const hint of plan.constraints.fieldHints) {
+    lines.push(hint.promptText);
+  }
+
+  if (plan.constraints.preserveHtmlStructure) {
+    lines.push("Preserve HTML text-node structure exactly; do not invent or drop tags.");
+  }
+
+  if (plan.constraints.preserveJsonStructure) {
+    lines.push("Preserve JSON/list structure exactly; only translate human-readable text leaves.");
+  }
+
+  if (modulePolicy) {
+    lines.push(`Module policy: ${modulePolicy.summary}`);
+    for (const line of modulePolicy.lines) {
+      lines.push(line);
+    }
+  }
+
+  return lines.length > 0 ? lines.join("\n") : null;
+}
+
+function inferModulePolicy(
+  context: ResolvedTranslationPromptContext,
+): InferredModulePolicy {
+  switch (context.scene) {
+    case "navigation_ui":
+      return {
+        summary: "compact navigation wording",
+        lines: [
+          "Keep labels concise and instantly scannable.",
+          "Prefer familiar navigation vocabulary over descriptive marketing phrasing.",
+        ],
+      };
+    case "theme_setting_copy":
+      return {
+        summary: "merchant-facing admin clarity",
+        lines: [
+          "Favor concise merchant-facing wording suitable for settings panels.",
+          "Avoid decorative phrasing and keep operational meaning explicit.",
+        ],
+      };
+    case "seo_copy":
+      return {
+        summary: "search snippet clarity",
+        lines: [
+          "Balance fidelity with click-through clarity for search-facing copy.",
+          "Prefer concrete product/category wording over vague brand language.",
+        ],
+      };
+    case "transactional_template":
+      return {
+        summary: "trustworthy transactional tone",
+        lines: [
+          "Keep instructions and order-related wording precise and reassuring.",
+          "Do not turn transactional copy into promotional marketing language.",
+        ],
+      };
+    case "structured_content":
+      return {
+        summary: "structure-consistent reusable copy",
+        lines: [
+          "Keep parallel list or JSON items stylistically consistent.",
+          "Prefer stable wording that reads naturally when repeated across blocks.",
+        ],
+      };
+    case "strict_slug":
+      return {
+        summary: "stable slug semantics",
+        lines: [
+          "Preserve the core keyword signal with minimal rewriting.",
+          "Keep the wording stable enough for deterministic handle generation.",
+        ],
+      };
+    case "product_catalog":
+      if (context.fieldKind === "title" || context.fieldKind === "description") {
+        return {
+          summary: "conversion-safe catalog copy",
+          lines: [
+            "Keep wording natural for product discovery and purchase intent.",
+            "Preserve concrete product attributes, materials, and differentiators.",
+          ],
+        };
+      }
+      return null;
+    case "editorial_copy":
+      return {
+        summary: "readable long-form merchandising copy",
+        lines: [
+          "Maintain narrative flow while keeping the message commercially clear.",
+          "Allow natural phrasing, but avoid drifting away from the original claims.",
+        ],
+      };
+    default:
+      return null;
+  }
+}
+
+function sanitizeDebugToken(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, "_");
+}

--- a/packages/translation-core/src/promptContextBuilder.ts
+++ b/packages/translation-core/src/promptContextBuilder.ts
@@ -1,0 +1,173 @@
+import {
+  getTranslationFieldConstraintHints,
+  getTranslationFieldRule,
+  type TranslationConstraintOrigin,
+  type TranslationFieldRule,
+} from "./translationFieldLimits.js";
+import {
+  resolveTranslationScene,
+  type FieldContentClass,
+  type TranslationAudience,
+  type TranslationPromptProfileId,
+  type TranslationRewriteFreedom,
+  type TranslationRole,
+  type TranslationScene,
+} from "./translationSceneResolver.js";
+
+export type TranslationConstraintSet = {
+  preserveHtmlStructure: boolean;
+  preserveJsonStructure: boolean;
+  preserveSentinels: boolean;
+  preservePlaceholders: boolean;
+  noHtmlTagsInLeaf: boolean;
+  keepLeadingTrailingWhitespace: boolean;
+  maxChars?: number;
+  recommendedMaxChars?: number;
+  mustBeSlugLike?: boolean;
+  shortUiLabelPreferred?: boolean;
+  fieldHints: Array<{
+    code: string;
+    origin: TranslationConstraintOrigin;
+    promptText: string;
+    maxChars?: number;
+  }>;
+};
+
+export type ResolvedTranslationPromptContext = {
+  promptProfileId: TranslationPromptProfileId;
+  scene: TranslationScene;
+  role: TranslationRole | null;
+  module: string | null;
+  contentClass: FieldContentClass;
+  fieldKind: TranslationFieldRule["fieldKind"];
+  audience: TranslationAudience;
+  rewriteFreedom: TranslationRewriteFreedom;
+  constraints: TranslationConstraintSet;
+};
+
+export type TranslationPromptPlan = {
+  task: {
+    scene: TranslationScene;
+    role: TranslationRole | null;
+    fieldKind: TranslationFieldRule["fieldKind"];
+    fieldRule: TranslationFieldRule;
+    audience: TranslationAudience;
+    rewriteFreedom: TranslationRewriteFreedom;
+    contentClass: FieldContentClass;
+    module: string | null;
+  };
+  constraints: TranslationConstraintSet;
+  debugReasons: string[];
+};
+
+export function buildResolvedPromptContext(args: {
+  module?: string | null;
+  key: string;
+  contentClass: FieldContentClass;
+  shopifyType?: string | null;
+}): ResolvedTranslationPromptContext {
+  const resolution = resolveTranslationScene({
+    module: args.module,
+    key: args.key,
+    contentClass: args.contentClass,
+    shopifyType: args.shopifyType,
+  });
+  const fieldRule = getTranslationFieldRule(resolution.fieldKind);
+
+  return {
+    ...resolution,
+    constraints: {
+      preserveHtmlStructure:
+        resolution.contentClass === "html" || resolution.contentClass === "liquid_html",
+      preserveJsonStructure:
+        resolution.contentClass === "json" || resolution.contentClass === "list",
+      preserveSentinels: true,
+      preservePlaceholders: true,
+      noHtmlTagsInLeaf: true,
+      keepLeadingTrailingWhitespace: true,
+      maxChars: fieldRule.maxChars,
+      recommendedMaxChars: fieldRule.recommendedMaxChars,
+      mustBeSlugLike: fieldRule.mustBeSlugLike,
+      shortUiLabelPreferred: fieldRule.shortUiLabelPreferred,
+      fieldHints: getTranslationFieldConstraintHints(fieldRule),
+    },
+  };
+}
+
+export function buildPromptPlan(
+  context: ResolvedTranslationPromptContext,
+): TranslationPromptPlan {
+  const fieldRule = getTranslationFieldRule(context.fieldKind);
+  const debugReasons: string[] = [
+    `profile:${context.promptProfileId}`,
+    `scene:${context.scene}`,
+    `content:${context.contentClass}`,
+  ];
+  for (const hint of context.constraints.fieldHints) {
+    debugReasons.push(`constraint:${hint.code}:${hint.origin}`);
+  }
+
+  return {
+    task: {
+      scene: context.scene,
+      role: context.role,
+      fieldKind: context.fieldKind,
+      fieldRule,
+      audience: context.audience,
+      rewriteFreedom: context.rewriteFreedom,
+      contentClass: context.contentClass,
+      module: context.module,
+    },
+    constraints: context.constraints,
+    debugReasons,
+  };
+}
+
+export function buildPromptContextBlock(
+  context: ResolvedTranslationPromptContext,
+): string | null {
+  const plan = buildPromptPlan(context);
+  const lines: string[] = [];
+
+  lines.push(
+    `Task profile: ${plan.task.scene.replace(/_/g, " ")} (${plan.task.contentClass.replace(/_/g, " ")})`,
+  );
+
+  if (plan.task.role) {
+    lines.push(`Field role: ${plan.task.role.replace(/_/g, " ")}`);
+  }
+
+  if (plan.task.module) {
+    lines.push(`Module context: ${plan.task.module}`);
+  }
+
+  if (plan.task.audience === "merchant") {
+    lines.push("Audience: merchant admin UI copy. Keep wording clear and compact.");
+  } else if (plan.task.audience === "system") {
+    lines.push("Audience: system-facing value. Preserve stability over flourish.");
+  } else {
+    lines.push("Audience: storefront shoppers. Keep wording natural and conversion-safe.");
+  }
+
+  if (plan.task.rewriteFreedom === "strict") {
+    lines.push("Rewrite freedom: strict. Preserve intent and shape very closely.");
+  } else if (plan.task.rewriteFreedom === "balanced") {
+    lines.push("Rewrite freedom: balanced. Improve clarity, but stay compact and faithful.");
+  } else {
+    lines.push("Rewrite freedom: adaptive. Natural e-commerce phrasing is allowed.");
+  }
+
+  for (const hint of plan.constraints.fieldHints) {
+    lines.push(hint.promptText);
+  }
+
+  if (plan.constraints.preserveHtmlStructure) {
+    lines.push("Preserve HTML text-node structure exactly; do not invent or drop tags.");
+  }
+
+  if (plan.constraints.preserveJsonStructure) {
+    lines.push("Preserve JSON/list structure exactly; only translate human-readable text leaves.");
+  }
+
+  return lines.length > 0 ? lines.join("\n") : null;
+}

--- a/packages/translation-core/src/translationFieldLimits.ts
+++ b/packages/translation-core/src/translationFieldLimits.ts
@@ -4,8 +4,117 @@
  */
 export const SHOPIFY_TITLE_MAX_CHARS = 255;
 
+export type TranslationFieldKind =
+  | "title"
+  | "description"
+  | "body"
+  | "seo_title"
+  | "seo_description"
+  | "handle"
+  | "ui_label"
+  | "unknown";
+
+export type TranslationConstraintOrigin = "shopify_limit" | "scene_policy";
+
+export type TranslationFieldRule = {
+  fieldKind: TranslationFieldKind;
+  maxChars?: number;
+  recommendedMaxChars?: number;
+  mustBeSlugLike?: boolean;
+  shortUiLabelPreferred?: boolean;
+};
+
 export function isTitleFieldKey(key: string): boolean {
   return key.trim().toLowerCase() === "title";
+}
+
+export function getTranslationFieldRule(
+  fieldKind: TranslationFieldKind,
+): TranslationFieldRule {
+  switch (fieldKind) {
+    case "title":
+      return {
+        fieldKind,
+        maxChars: SHOPIFY_TITLE_MAX_CHARS,
+      };
+    case "seo_title":
+      return {
+        fieldKind,
+        recommendedMaxChars: 70,
+      };
+    case "seo_description":
+      return {
+        fieldKind,
+        recommendedMaxChars: 160,
+      };
+    case "handle":
+      return {
+        fieldKind,
+        mustBeSlugLike: true,
+      };
+    case "ui_label":
+      return {
+        fieldKind,
+        recommendedMaxChars: 60,
+        shortUiLabelPreferred: true,
+      };
+    default:
+      return { fieldKind };
+  }
+}
+
+export function getTranslationFieldConstraintHints(
+  rule: TranslationFieldRule,
+): Array<{
+  code: string;
+  origin: TranslationConstraintOrigin;
+  promptText: string;
+  maxChars?: number;
+}> {
+  const hints: Array<{
+    code: string;
+    origin: TranslationConstraintOrigin;
+    promptText: string;
+    maxChars?: number;
+  }> = [];
+
+  if (rule.maxChars != null) {
+    hints.push({
+      code: "max_chars",
+      origin: "shopify_limit",
+      promptText: `Keep the translated value within ${rule.maxChars} characters while preserving the core meaning.`,
+      maxChars: rule.maxChars,
+    });
+  }
+
+  if (rule.recommendedMaxChars != null) {
+    hints.push({
+      code: "recommended_max_chars",
+      origin: "scene_policy",
+      promptText: `Prefer a concise translation around ${rule.recommendedMaxChars} characters or less unless clarity would suffer.`,
+      maxChars: rule.recommendedMaxChars,
+    });
+  }
+
+  if (rule.mustBeSlugLike) {
+    hints.push({
+      code: "slug_like",
+      origin: "scene_policy",
+      promptText:
+        "Keep the result slug-like: plain text only, concise, stable, and suitable for URL handle generation after hyphen joining.",
+    });
+  }
+
+  if (rule.shortUiLabelPreferred) {
+    hints.push({
+      code: "short_ui_label",
+      origin: "scene_policy",
+      promptText:
+        "Prefer a short UI label that remains clear at a glance and avoids unnecessary wording.",
+    });
+  }
+
+  return hints;
 }
 
 /**

--- a/packages/translation-core/src/translationSceneResolver.ts
+++ b/packages/translation-core/src/translationSceneResolver.ts
@@ -1,0 +1,269 @@
+export type FieldContentClass = "html" | "liquid_html" | "json" | "list" | "plain";
+
+export type TranslationPromptProfileId =
+  | "catalog_v1"
+  | "seo_v1"
+  | "navigation_v1"
+  | "theme_ui_v1"
+  | "editorial_v1"
+  | "structured_content_v1"
+  | "transactional_v1"
+  | "slug_v1";
+
+export type TranslationScene =
+  | "product_catalog"
+  | "seo_copy"
+  | "navigation_ui"
+  | "theme_setting_copy"
+  | "editorial_copy"
+  | "structured_content"
+  | "transactional_template"
+  | "strict_slug";
+
+export type TranslationRole =
+  | "heading"
+  | "title"
+  | "description"
+  | "button_label"
+  | "menu_label"
+  | "label"
+  | "body";
+
+export type TranslationAudience = "shopper" | "merchant" | "system";
+export type TranslationRewriteFreedom = "strict" | "balanced" | "adaptive";
+
+export type TranslationSceneResolution = {
+  promptProfileId: TranslationPromptProfileId;
+  scene: TranslationScene;
+  role: TranslationRole | null;
+  module: string | null;
+  contentClass: FieldContentClass;
+  fieldKind:
+    | "title"
+    | "description"
+    | "body"
+    | "seo_title"
+    | "seo_description"
+    | "handle"
+    | "ui_label"
+    | "unknown";
+  audience: TranslationAudience;
+  rewriteFreedom: TranslationRewriteFreedom;
+};
+
+const THEME_MODULE_RE = /^ONLINE_STORE_THEME_/i;
+const CATALOG_MODULE_RE =
+  /^(PRODUCT|COLLECTION|PRODUCT_OPTION|PRODUCT_OPTION_VALUE|FILTER|METAOBJECT|METAFIELD)$/i;
+const NAVIGATION_MODULE_RE = /^(MENU|LINK)$/i;
+const EDITORIAL_MODULE_RE = /^(ARTICLE|BLOG|PAGE)$/i;
+const TRANSACTIONAL_MODULE_RE =
+  /^(EMAIL_TEMPLATE|PACKING_SLIP_TEMPLATE|SHOP_POLICY|DELIVERY_METHOD_DEFINITION)$/i;
+
+const ROLE_PATTERNS: Array<{ role: TranslationRole; re: RegExp }> = [
+  { role: "button_label", re: /button_label|button-text|cta|shop_now|buy_now|link_label/i },
+  { role: "heading", re: /heading|headline|title/i },
+  { role: "description", re: /description|desc|summary|meta_description/i },
+  { role: "menu_label", re: /menu.*label|nav.*label|navigation.*label/i },
+  { role: "label", re: /label|placeholder|hint|help/i },
+  { role: "body", re: /body|content|text|copy|html/i },
+];
+
+export function resolveTranslationScene(args: {
+  module?: string | null;
+  key: string;
+  contentClass: FieldContentClass;
+  shopifyType?: string | null;
+}): TranslationSceneResolution {
+  const module = normalizeModule(args.module ?? args.shopifyType);
+  const key = (args.key ?? "").trim();
+  const keyBlob = `${module ?? ""} ${key}`.toLowerCase();
+  const fieldKind = resolveFieldKind(key);
+  const role = resolveRole(keyBlob, fieldKind);
+
+  if (fieldKind === "handle") {
+    return finalizeTranslationSceneResolution({
+      promptProfileId: "slug_v1",
+      scene: "strict_slug",
+      role,
+      module,
+      contentClass: args.contentClass,
+      fieldKind,
+    });
+  }
+
+  if (fieldKind === "seo_title" || fieldKind === "seo_description") {
+    return finalizeTranslationSceneResolution({
+      promptProfileId: "seo_v1",
+      scene: "seo_copy",
+      role,
+      module,
+      contentClass: args.contentClass,
+      fieldKind,
+    });
+  }
+
+  if (args.contentClass === "json" || args.contentClass === "list") {
+    return finalizeTranslationSceneResolution({
+      promptProfileId: "structured_content_v1",
+      scene: "structured_content",
+      role,
+      module,
+      contentClass: args.contentClass,
+      fieldKind,
+    });
+  }
+
+  if (isNavigationModule(module)) {
+    return finalizeTranslationSceneResolution({
+      promptProfileId: "navigation_v1",
+      scene: "navigation_ui",
+      role,
+      module,
+      contentClass: args.contentClass,
+      fieldKind,
+    });
+  }
+
+  if (isTransactionalModule(module)) {
+    return finalizeTranslationSceneResolution({
+      promptProfileId: "transactional_v1",
+      scene: "transactional_template",
+      role,
+      module,
+      contentClass: args.contentClass,
+      fieldKind,
+    });
+  }
+
+  if (isThemeModule(module)) {
+    return finalizeTranslationSceneResolution({
+      promptProfileId: "theme_ui_v1",
+      scene: "theme_setting_copy",
+      role,
+      module,
+      contentClass: args.contentClass,
+      fieldKind,
+    });
+  }
+
+  if (isEditorialModule(module) || args.contentClass === "html" || args.contentClass === "liquid_html") {
+    return finalizeTranslationSceneResolution({
+      promptProfileId: "editorial_v1",
+      scene: "editorial_copy",
+      role,
+      module,
+      contentClass: args.contentClass,
+      fieldKind,
+    });
+  }
+
+  if (isCatalogModule(module)) {
+    return finalizeTranslationSceneResolution({
+      promptProfileId: "catalog_v1",
+      scene: "product_catalog",
+      role,
+      module,
+      contentClass: args.contentClass,
+      fieldKind,
+    });
+  }
+
+  return finalizeTranslationSceneResolution({
+    promptProfileId: "catalog_v1",
+    scene: "product_catalog",
+    role,
+    module,
+    contentClass: args.contentClass,
+    fieldKind,
+  });
+}
+
+export function finalizeTranslationSceneResolution(
+  base: Omit<TranslationSceneResolution, "audience" | "rewriteFreedom">,
+): TranslationSceneResolution {
+  return {
+    ...base,
+    audience: resolveAudience(base.scene),
+    rewriteFreedom: resolveRewriteFreedom(base.scene, base.role, base.contentClass),
+  };
+}
+
+function normalizeModule(module: string | null | undefined): string | null {
+  const normalized = (module ?? "").trim();
+  return normalized ? normalized.toUpperCase() : null;
+}
+
+function resolveFieldKind(
+  key: string,
+):
+  | "title"
+  | "description"
+  | "body"
+  | "seo_title"
+  | "seo_description"
+  | "handle"
+  | "ui_label"
+  | "unknown" {
+  const value = key.trim().toLowerCase();
+  if (value === "handle") return "handle";
+  if (value === "meta_title") return "seo_title";
+  if (value === "meta_description") return "seo_description";
+  if (value === "title") return "title";
+  if (value.includes("description") || value === "summary") return "description";
+  if (/label|placeholder|hint|help|button|cta/.test(value)) return "ui_label";
+  if (/body|content|html|text/.test(value)) return "body";
+  return "unknown";
+}
+
+function resolveRole(
+  keyBlob: string,
+  fieldKind: TranslationSceneResolution["fieldKind"],
+): TranslationRole | null {
+  for (const candidate of ROLE_PATTERNS) {
+    if (candidate.re.test(keyBlob)) return candidate.role;
+  }
+  if (fieldKind === "title" || fieldKind === "seo_title") return "title";
+  if (fieldKind === "description" || fieldKind === "seo_description") return "description";
+  if (fieldKind === "ui_label") return "label";
+  if (fieldKind === "body") return "body";
+  return null;
+}
+
+function isThemeModule(module: string | null): boolean {
+  return module != null && THEME_MODULE_RE.test(module);
+}
+
+function isCatalogModule(module: string | null): boolean {
+  return module != null && CATALOG_MODULE_RE.test(module);
+}
+
+function isNavigationModule(module: string | null): boolean {
+  return module != null && NAVIGATION_MODULE_RE.test(module);
+}
+
+function isEditorialModule(module: string | null): boolean {
+  return module != null && EDITORIAL_MODULE_RE.test(module);
+}
+
+function isTransactionalModule(module: string | null): boolean {
+  return module != null && TRANSACTIONAL_MODULE_RE.test(module);
+}
+
+function resolveAudience(scene: TranslationScene): TranslationAudience {
+  if (scene === "theme_setting_copy" || scene === "navigation_ui") return "merchant";
+  if (scene === "strict_slug") return "system";
+  return "shopper";
+}
+
+function resolveRewriteFreedom(
+  scene: TranslationScene,
+  role: TranslationRole | null,
+  contentClass: FieldContentClass,
+): TranslationRewriteFreedom {
+  if (scene === "strict_slug") return "strict";
+  if (scene === "navigation_ui" || role === "menu_label" || role === "button_label") {
+    return "balanced";
+  }
+  if (contentClass === "json" || contentClass === "list") return "balanced";
+  return "adaptive";
+}


### PR DESCRIPTION
## 背景

当前 `translation-core` 的 prompt 组装主要依赖硬编码逻辑，不同字段场景在批量翻译时容易共用同一类 prompt 池，扩展字段级约束和场景策略也不够自然。

旧分支里更完整的 prompt 子系统无法直接无损迁回当前 `master`，因此这次先重建一个最小可运行版本，只恢复主链真正需要的通用能力。

## 本 PR 做了什么

- 新增最小场景解析层，根据 `field key`、`content class`、`shopifyType/module` 推断 prompt profile、scene、audience 和 rewrite freedom
- 新增字段约束模型，统一承载 title 长度、SEO 推荐长度、slug 约束、短 UI label 偏好等规则
- 新增最小 prompt context builder，生成 task / constraint / module policy block
- 在 `llmTranslate` 中接入新的 prompt planner
- 将 `poolSig` 细化到 `promptProfileId` 级别，避免不同字段场景混用同一个 prompt 池

## 这次额外补强

- 为通用场景增加了轻量 `module policy` 推断
- 不依赖任何外部上下文，只基于 scene 自动补充场景化文案约束
- 当前覆盖场景：
  - `navigation_ui`
  - `theme_setting_copy`
  - `seo_copy`
  - `transactional_template`
  - `structured_content`
  - `strict_slug`
  - `product_catalog`
  - `editorial_copy`

## 不包含

- 不包含 `shop profile` 注入
- 不包含 `market context`
- 不包含 `theme scene hint`
- 不包含 app/worker 调用面改造
- 不重建旧版完整 prompt 子系统

## 收益

- 让 prompt 规则从单点硬编码提升为最小可扩展 planner
- 让字段级约束和场景策略有明确承载点
- 避免不同字段场景在批量翻译时错误共池
- 为后续增量接入 terminology / market / profile 留出稳定骨架

## 验证

- `npm run core:build`