### PR TITLE
修复 switcher 无法替换组件属性文案

### DIFF
--- a/extensions/ciwi-switcher/assets/ciwi-main.js
+++ b/extensions/ciwi-switcher/assets/ciwi-main.js
@@ -109,6 +109,41 @@ function detectRuntimeLanguage(ciwiBlock, availableLanguages) {
   return "";
 }
 
+function isShopifyThemePreviewContext() {
+  const currentUrl = new URL(window.location.href);
+  const params = currentUrl.searchParams;
+  const referrer = String(document.referrer || "");
+
+  if (document.documentElement.classList.contains("shopify-design-mode")) {
+    return true;
+  }
+
+  if (window.Shopify?.designMode === true) {
+    return true;
+  }
+
+  // 主题预览链接通常会带 preview_theme_id；部分预览链路还会附带 _ab/_fd/pb。
+  if (params.has("preview_theme_id") || params.has("preview_token")) {
+    return true;
+  }
+
+  // Shopify Admin 主题编辑器里，店铺预览通常运行在 iframe 中，
+  // 当前 storefront URL 可能不带 preview_theme_id，但 referrer 会是 editor 地址。
+  if (
+    referrer.includes("admin.shopify.com/store/") &&
+    referrer.includes("/themes/") &&
+    referrer.includes("/editor")
+  ) {
+    return true;
+  }
+
+  return (
+    params.has("_ab") &&
+    params.has("_fd") &&
+    params.has("pb")
+  );
+}
+
 async function ciwiOnload() {
   const blockId = document.querySelector('input[name="block_id"]')?.value;
   if (!blockId) return console.warn("blockId not found");
@@ -216,9 +251,14 @@ async function ciwiOnload() {
 
   let detectedCountry = preferredCountry || countryValue;
   let detectedLanguage = preferredLanguage || browserLanguage;
+  const isInThemePreview = isShopifyThemePreviewContext();
+  const shouldRunAutoLocalization =
+    !isInThemePreview &&
+    configData?.ipOpen &&
+    !hasUserLocalizationData;
 
   // IP 定位：每次进入都重新请求，不使用 localStorage 缓存
-  if (configData?.ipOpen && !hasUserLocalizationData) {
+  if (shouldRunAutoLocalization) {
     const iptokenValue = ciwiBlock.querySelector(
       'input[name="iptoken"]',
     )?.value;
@@ -247,7 +287,7 @@ async function ciwiOnload() {
   );
 
   //不在主题编辑器内
-  if (!isInThemeEditor && configData?.ipOpen && !hasUserLocalizationData) {
+  if (!isInThemeEditor && shouldRunAutoLocalization) {
     //需要定位逻辑
     if (
       detectedCountry &&

--- a/extensions/ciwi-switcher/assets/ciwi-ui.js
+++ b/extensions/ciwi-switcher/assets/ciwi-ui.js
@@ -1297,6 +1297,13 @@ export async function CustomLiquidTextTranslate(blockId, shop, ciwiBlock) {
     );
 
     const nodes = [];
+    if (
+      root instanceof Element &&
+      !skipTags.has(root.nodeName) &&
+      !(ciwiBlock && ciwiBlock.contains(root))
+    ) {
+      nodes.push(root);
+    }
     while (walker.nextNode()) nodes.push(walker.currentNode);
 
     const replacements = [];
@@ -1552,6 +1559,181 @@ export async function CustomLiquidTextTranslate(blockId, shop, ciwiBlock) {
     });
   };
 
+  const textLikeAttributeNames = new Set([
+    "alt",
+    "aria-label",
+    "caption",
+    "header-text",
+    "label",
+    "placeholder",
+    "subtitle",
+    "text",
+    "title",
+  ]);
+
+  const blockedAttributeNames = new Set([
+    "class",
+    "content",
+    "href",
+    "id",
+    "name",
+    "rel",
+    "role",
+    "src",
+    "srcset",
+    "style",
+    "target",
+    "value",
+  ]);
+
+  const isTranslatableAttribute = (node, attribute) => {
+    if (!node || !attribute) return false;
+    const attrName = String(attribute.name || "").trim().toLowerCase();
+    if (!attrName || blockedAttributeNames.has(attrName)) return false;
+    if (attrName.startsWith("on")) return false;
+    if (!String(attribute.value ?? "").trim()) return false;
+    if (textLikeAttributeNames.has(attrName) || attrName.startsWith("aria-")) {
+      return true;
+    }
+
+    // 允许 web component 上常见的 *-text / *-title / *-label 这类展示属性。
+    return Boolean(
+      node.tagName?.includes("-") &&
+        /(?:text|title|label|caption|subtitle)$/i.test(attrName),
+    );
+  };
+
+  const replaceAttributeEntriesFast = (
+    exactEntryList,
+    fuzzyEntryList,
+    root = document.body,
+  ) => {
+    if (!root?.isConnected) return;
+
+    const exactMap = new Map();
+    exactEntryList.forEach(({ before, after }) => {
+      const trimmedBefore = before?.trim();
+      const afterRaw = String(after ?? "");
+      if (!trimmedBefore || afterRaw.trim() === "") return;
+      const key = shouldFlexibleWhitespaceMatch(trimmedBefore)
+        ? normalizeCollapsedText(trimmedBefore)
+        : normalizeText(trimmedBefore);
+      exactMap.set(key, { replacement: afterRaw });
+    });
+
+    const fuzzyPreparedEntries = [];
+    fuzzyEntryList.forEach(({ before, after }) => {
+      const trimmedBefore = before?.trim();
+      const afterRaw = String(after ?? "");
+      if (!trimmedBefore || afterRaw.trim() === "") return;
+      const flexibleWhitespace = shouldFlexibleWhitespaceMatch(trimmedBefore);
+      fuzzyPreparedEntries.push({
+        trimmedBefore,
+        afterRaw,
+        flexibleWhitespace,
+        collapsedBefore: flexibleWhitespace
+          ? normalizeCollapsedText(trimmedBefore)
+          : null,
+        re: new RegExp(
+          flexibleWhitespace
+            ? escapeRegExp(trimmedBefore).replace(/\s+/g, "\\s+")
+            : escapeRegExp(trimmedBefore),
+          "g",
+        ),
+      });
+    });
+
+    if (exactMap.size === 0 && fuzzyPreparedEntries.length === 0) return;
+
+    const walker = document.createTreeWalker(
+      root,
+      NodeFilter.SHOW_ELEMENT,
+      {
+        acceptNode(node) {
+          const tag = node?.nodeName;
+          if (skipTags.has(tag)) return NodeFilter.FILTER_REJECT;
+          if (ciwiBlock && ciwiBlock.contains(node)) return NodeFilter.FILTER_REJECT;
+          return NodeFilter.FILTER_ACCEPT;
+        },
+      },
+    );
+
+    const nodes = [];
+    if (
+      root instanceof Element &&
+      !skipTags.has(root.nodeName) &&
+      !(ciwiBlock && ciwiBlock.contains(root))
+    ) {
+      nodes.push(root);
+    }
+    while (walker.nextNode()) nodes.push(walker.currentNode);
+
+    nodes.forEach((node) => {
+      if (!(node instanceof Element)) return;
+      if (isElementHiddenForTranslation(node)) return;
+
+      Array.from(node.attributes || []).forEach((attribute) => {
+        if (!isTranslatableAttribute(node, attribute)) return;
+
+        const original = attribute.value;
+        const strictKey = normalizeText(original);
+        const collapsedKey = normalizeCollapsedText(original);
+        const exactEntry = exactMap.get(strictKey) || exactMap.get(collapsedKey);
+        if (exactEntry) {
+          const replacement = preserveBoundaryWhitespace(
+            original,
+            exactEntry.replacement,
+          );
+          if (debugLiquidTranslate && debugReplaceTextCount < 20) {
+            debugReplaceTextCount += 1;
+            debugLog("replace:attribute", {
+              tag: node.nodeName,
+              attr: attribute.name,
+              before: summarize(original, 200),
+              after: summarize(replacement, 200),
+            });
+          }
+          node.setAttribute(attribute.name, replacement);
+          return;
+        }
+
+        let nextValue = original;
+        let normalized = normalizeText(nextValue);
+        let collapsed = null;
+
+        for (const entry of fuzzyPreparedEntries) {
+          if (entry.flexibleWhitespace && collapsed === null) {
+            collapsed = normalizeCollapsedText(normalized);
+          }
+          const matches = entry.flexibleWhitespace
+            ? collapsed.includes(entry.collapsedBefore)
+            : normalized.includes(entry.trimmedBefore);
+          if (!matches) continue;
+
+          nextValue = preserveBoundaryWhitespace(
+            nextValue,
+            nextValue.replace(entry.re, () => entry.afterRaw),
+          );
+          normalized = normalizeText(nextValue);
+          collapsed = null;
+        }
+
+        if (nextValue !== original) {
+          if (debugLiquidTranslate && debugReplaceTextCount < 20) {
+            debugReplaceTextCount += 1;
+            debugLog("replace:attribute", {
+              tag: node.nodeName,
+              attr: attribute.name,
+              before: summarize(original, 200),
+              after: summarize(nextValue, 200),
+            });
+          }
+          node.setAttribute(attribute.name, nextValue);
+        }
+      });
+    });
+  };
+
   const hasHtmlEntries = (entryList) =>
     entryList.some(
       ({ before, after }) => looksLikeHtml(before) || looksLikeHtml(after),
@@ -1567,6 +1749,13 @@ export async function CustomLiquidTextTranslate(blockId, shop, ciwiBlock) {
   const collectMutationRoots = (mutations) => {
     const roots = [];
     for (const mutation of mutations) {
+      if (mutation.type === "attributes") {
+        const target = mutation.target;
+        if (target?.nodeType === Node.ELEMENT_NODE && !shouldSkipTranslationRoot(target)) {
+          roots.push(target);
+        }
+        continue;
+      }
       if (mutation.type !== "childList") continue;
       for (const node of mutation.addedNodes) {
         if (node.nodeType === Node.ELEMENT_NODE) {
@@ -1596,11 +1785,45 @@ export async function CustomLiquidTextTranslate(blockId, shop, ciwiBlock) {
     );
     if (targets.length === 0) return;
 
+    const scopes = [];
+    const seenScopes = new Set();
+    const pushScope = (scope) => {
+      if (!scope?.isConnected || seenScopes.has(scope)) return;
+      seenScopes.add(scope);
+      scopes.push(scope);
+    };
+
     for (const root of targets) {
+      pushScope(root);
+      if (root instanceof Element && root.shadowRoot) {
+        pushScope(root.shadowRoot);
+      }
+      const shadowWalker = document.createTreeWalker(
+        root,
+        NodeFilter.SHOW_ELEMENT,
+        {
+          acceptNode(node) {
+            const tag = node?.nodeName;
+            if (skipTags.has(tag)) return NodeFilter.FILTER_REJECT;
+            if (ciwiBlock && ciwiBlock.contains(node)) return NodeFilter.FILTER_REJECT;
+            return NodeFilter.FILTER_ACCEPT;
+          },
+        },
+      );
+
+      while (shadowWalker.nextNode()) {
+        if (shadowWalker.currentNode.shadowRoot) {
+          pushScope(shadowWalker.currentNode.shadowRoot);
+        }
+      }
+    }
+
+    for (const root of scopes) {
       if (hasHtmlEntries(exactEntries) || hasHtmlEntries(fuzzyEntries)) {
         replaceHtmlExactEntries(exactEntries, root);
         replaceHtmlExactEntries(fuzzyEntries, root);
       }
+      replaceAttributeEntriesFast(exactEntries, fuzzyEntries, root);
       replaceExactEntriesFast(exactEntries, root);
       replaceFuzzyEntriesFast(fuzzyEntries, root);
     }
@@ -1647,7 +1870,22 @@ export async function CustomLiquidTextTranslate(blockId, shop, ciwiBlock) {
         scheduleIncrementalRun();
       });
 
-      observer.observe(document.body, { childList: true, subtree: true });
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: [
+          "alt",
+          "aria-label",
+          "caption",
+          "header-text",
+          "label",
+          "placeholder",
+          "subtitle",
+          "text",
+          "title",
+        ],
+      });
       window[observerKey] = observer;
 
       setTimeout(() => {

--- a/extensions/ciwi-switcher/assets/ciwi-ui.js
+++ b/extensions/ciwi-switcher/assets/ciwi-ui.js
@@ -14,8 +14,12 @@ import {
   resolveStorefrontProductId,
 } from "./ciwi-page.js";
 import { useCacheThenRefresh } from "./ciwi-storage.js";
-import { persistManualLocalizationPreference } from "./ciwi-utils.js";
-import { isLikelyMoneyText, transformPrices } from "./ciwi-utils.js";
+import {
+  CIWI_MONEY_SELECTOR,
+  persistManualLocalizationPreference,
+  shouldTrackMoneyNode,
+  transformPrices,
+} from "./ciwi-utils.js";
 
 /**
  * Skip hidden nodes during translation without forcing style recalc on every walker step.
@@ -252,6 +256,38 @@ async function refreshSelectedCurrency({ blockId, shop, ciwiBlock }) {
   await initializeCurrency({ blockId, currencyData, shop, ciwiBlock });
 }
 
+function syncCurrencySelectionState({
+  ciwiBlock,
+  currencySelect,
+  selectedCurrencyCode,
+  persist = true,
+}) {
+  const nextCode = String(selectedCurrencyCode || "").trim();
+  const currencyInput = ciwiBlock?.querySelector('input[name="currency_code"]');
+  if (currencySelect && nextCode && currencySelect.value !== nextCode) {
+    currencySelect.value = nextCode;
+  }
+  if (currencyInput && currencyInput.value !== nextCode) {
+    currencyInput.value = nextCode;
+    currencyInput.setAttribute("value", nextCode);
+  }
+  if (persist && typeof localStorage !== "undefined" && nextCode) {
+    localStorage.setItem("ciwi_selected_currency", nextCode);
+  }
+
+  const languageSelectorContainer = ciwiBlock?.querySelector(
+    "#language-switcher-container",
+  );
+  const currencySelectorContainer = ciwiBlock?.querySelector(
+    "#currency-switcher-container",
+  );
+  updateDisplayText(
+    languageSelectorContainer?.style.display === "block",
+    currencySelectorContainer?.style.display === "block",
+    ciwiBlock,
+  );
+}
+
 /**
  * 初始化货币选择器
  */
@@ -311,9 +347,11 @@ export async function initializeCurrency({
     fallbackCurrencyCode: pageCurrencyCode,
   });
 
-  if (currencySelect && effectiveSelectedCurrencyCode) {
-    currencySelect.value = effectiveSelectedCurrencyCode;
-  }
+  syncCurrencySelectionState({
+    ciwiBlock,
+    currencySelect,
+    selectedCurrencyCode: effectiveSelectedCurrencyCode,
+  });
 
   if (activePriceObserver) {
     activePriceObserver.disconnect();
@@ -324,6 +362,11 @@ export async function initializeCurrency({
     !selectedCurrency ||
     effectiveSelectedCurrencyCode === baseCurrencyCode
   ) {
+    syncCurrencySelectionState({
+      ciwiBlock,
+      currencySelect,
+      selectedCurrencyCode: baseCurrencyCode,
+    });
     transformPrices({ rate: 1, moneyFormat, selectedCurrency: null });
     return;
   }
@@ -353,6 +396,14 @@ export async function initializeCurrency({
       if (typeof autoRate == "number") {
         rate = autoRate;
       } else {
+        syncCurrencySelectionState({
+          ciwiBlock,
+          currencySelect,
+          selectedCurrencyCode: baseCurrencyCode,
+        });
+        if (typeof localStorage !== "undefined") {
+          localStorage.removeItem("ciwi_selected_currency_rate");
+        }
         transformPrices({ rate: 1, moneyFormat, selectedCurrency: null });
         return;
       }
@@ -370,6 +421,14 @@ export async function initializeCurrency({
   } else {
     rate = Number(selectedCurrency.exchangeRate);
     if (!Number.isFinite(rate)) {
+      syncCurrencySelectionState({
+        ciwiBlock,
+        currencySelect,
+        selectedCurrencyCode: baseCurrencyCode,
+      });
+      if (typeof localStorage !== "undefined") {
+        localStorage.removeItem("ciwi_selected_currency_rate");
+      }
       transformPrices({ rate: 1, moneyFormat, selectedCurrency: null });
       return;
     }
@@ -383,8 +442,7 @@ export async function initializeCurrency({
  * 观察 DOM 变化，动态处理新价格
  */
 export function initPriceObserver({ rate, moneyFormat, selectedCurrency }) {
-  const moneySelector =
-    ".ciwi-money, .money, .price-item, [data-money], [data-price], span.price";
+  const moneySelector = CIWI_MONEY_SELECTOR;
   if (activePriceObserver) {
     activePriceObserver.disconnect();
   }
@@ -399,7 +457,7 @@ export function initPriceObserver({ rate, moneyFormat, selectedCurrency }) {
         const add = (el) => {
           if (!(el instanceof Element)) return;
           if (!el.classList.contains("ciwi-money")) {
-            if (!isLikelyMoneyText(el.textContent || el.innerText || "")) return;
+            if (!shouldTrackMoneyNode(el)) return;
             el.classList.add("ciwi-money");
           }
           pending.add(el);

--- a/extensions/ciwi-switcher/assets/ciwi-utils.js
+++ b/extensions/ciwi-switcher/assets/ciwi-utils.js
@@ -83,6 +83,29 @@ function formatWithSpaceAndPeriod(integerPart, decimalPart) {
 
 const CURRENCY_SYMBOL_RE = /[$€£¥₹₩₽₺₫₴₦₱₪₡₲₵]/;
 const CURRENCY_CODE_RE = /\b[A-Z]{3}\b/;
+const MONEY_FRAGMENT_RE =
+  /(?:\b[A-Z]{3}\b\s*)?[$€£¥₹₩₽₺₫₴₦₱₪₡₲₵]?\s*\d[\d\s,.'’]*(?:[.,]\d+)?(?:\s*\b[A-Z]{3}\b)?/g;
+
+export const CIWI_MONEY_SELECTOR = [
+  ".ciwi-money",
+  ".money",
+  ".price",
+  ".price-item",
+  ".price__current",
+  ".price__sale",
+  ".price__regular",
+  ".product-price",
+  ".product__price",
+  "[data-money]",
+  "[data-price]",
+  "[data-product-price]",
+  "[data-regular-price]",
+  "[data-sale-price]",
+  "span.price",
+  "sale-price",
+  "compare-at-price",
+  "unit-price",
+].join(", ");
 
 export function isLikelyMoneyText(text) {
   const value = String(text || "").replace(/\s+/g, " ").trim();
@@ -92,11 +115,21 @@ export function isLikelyMoneyText(text) {
   return CURRENCY_SYMBOL_RE.test(value) || CURRENCY_CODE_RE.test(value);
 }
 
+export function shouldTrackMoneyNode(node) {
+  if (!(node instanceof Element)) return false;
+  if (!isLikelyMoneyText(node.textContent || node.innerText || "")) return false;
+
+  const nestedCandidate = node.querySelector(CIWI_MONEY_SELECTOR);
+  if (!nestedCandidate) return true;
+
+  return !isLikelyMoneyText(
+    nestedCandidate.textContent || nestedCandidate.innerText || "",
+  );
+}
+
 function collectMoneyNodes(root) {
   const scope = root || document;
-  const nodes = scope.querySelectorAll(
-    ".ciwi-money, .money, .price-item, [data-money], [data-price], span.price",
-  );
+  const nodes = scope.querySelectorAll(CIWI_MONEY_SELECTOR);
   const list = [];
   nodes.forEach((node) => {
     if (!(node instanceof Element)) return;
@@ -104,11 +137,94 @@ function collectMoneyNodes(root) {
       list.push(node);
       return;
     }
-    if (!isLikelyMoneyText(node.textContent || node.innerText || "")) return;
+    if (!shouldTrackMoneyNode(node)) return;
     node.classList.add("ciwi-money");
     list.push(node);
   });
   return list;
+}
+
+function normalizeMoneySourceText(text) {
+  return String(text || "")
+    .replace(/[\u00A0\u202F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractMoneyFragment(text) {
+  const normalized = normalizeMoneySourceText(text);
+  if (!normalized) return "";
+
+  const matches = normalized.match(MONEY_FRAGMENT_RE) || [];
+  return (
+    matches.find(
+      (match) =>
+        /\d/.test(match) &&
+        (CURRENCY_SYMBOL_RE.test(match) || CURRENCY_CODE_RE.test(match)),
+    ) || ""
+  );
+}
+
+function escapeRegExp(text) {
+  return String(text || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildConvertedPriceText(detectedPrice, selectedCurrency) {
+  const currencyConfig = window.currencyFormatConfig
+    ? window.currencyFormatConfig[selectedCurrency.currencyCode]
+    : null;
+  const symbol = selectedCurrency.symbol || "";
+  const symbolPosition = currencyConfig
+    ? currencyConfig.symbol_position
+    : "front";
+
+  if (symbolPosition === "back") {
+    return `${detectedPrice}${symbol} ${selectedCurrency.currencyCode}`.trim();
+  }
+
+  return `${symbol}${detectedPrice} ${selectedCurrency.currencyCode}`.trim();
+}
+
+function replaceMoneyFragmentInOriginalHtml(node, originalHtml, originalText, nextText) {
+  const moneyFragment = extractMoneyFragment(originalText);
+  if (!moneyFragment) {
+    node.textContent = nextText;
+    return;
+  }
+
+  const template = document.createElement("template");
+  template.innerHTML = originalHtml;
+  const walker = document.createTreeWalker(
+    template.content,
+    NodeFilter.SHOW_TEXT,
+  );
+
+  let replaced = false;
+  while (walker.nextNode()) {
+    const textNode = walker.currentNode;
+    const textValue = textNode.nodeValue || "";
+    if (!extractMoneyFragment(textValue)) continue;
+
+    const replacementRegex = new RegExp(escapeRegExp(moneyFragment).replace(/\s+/g, "\\s*"));
+    if (!replacementRegex.test(normalizeMoneySourceText(textValue))) continue;
+
+    textNode.nodeValue = normalizeMoneySourceText(textValue).replace(
+      replacementRegex,
+      nextText,
+    );
+    replaced = true;
+    break;
+  }
+
+  if (replaced) {
+    node.innerHTML = template.innerHTML;
+    return;
+  }
+
+  node.textContent = normalizeMoneySourceText(originalText).replace(
+    new RegExp(escapeRegExp(moneyFragment).replace(/\s+/g, "\\s*")),
+    nextText,
+  );
 }
 
 export function detectNumberFormat(moneyFormat, transformedPrice, rounding) {
@@ -185,7 +301,11 @@ export function transformSinglePriceNode(
   }
 
   const priceText = node.dataset.ciwiOriginalPriceText || node.innerText;
-  const formatted = priceText.replace(/[^0-9,. ]/g, "").trim();
+  const moneyFragment = extractMoneyFragment(priceText);
+  const formatted = moneyFragment
+    .replace(/[^\d,.\s'’]/g, "")
+    .replace(/’/g, "'")
+    .trim();
   if (!formatted || rate === "Auto") return;
   if (
     node.dataset.ciwiCurrencyCode === selectedCurrency.currencyCode &&
@@ -201,18 +321,14 @@ export function transformSinglePriceNode(
     transformedPrice,
     selectedCurrency.rounding,
   );
-  const currencyConfig = window.currencyFormatConfig
-    ? window.currencyFormatConfig[selectedCurrency.currencyCode]
-    : null;
-  const symbol = selectedCurrency.symbol || "";
-  const symbolPosition = currencyConfig
-    ? currencyConfig.symbol_position
-    : "front";
-  if (symbolPosition === "back") {
-    node.innerHTML = `${detected}${symbol} <span class="currency-code">${selectedCurrency.currencyCode}</span>`;
-  } else {
-    node.innerHTML = `${symbol}${detected} <span class="currency-code">${selectedCurrency.currencyCode}</span>`;
-  }
+  const nextText = buildConvertedPriceText(detected, selectedCurrency);
+
+  replaceMoneyFragmentInOriginalHtml(
+    node,
+    node.dataset.ciwiOriginalPriceHtml || node.innerHTML,
+    priceText,
+    nextText,
+  );
   node.dataset.ciwiCurrencyCode = selectedCurrency.currencyCode;
   node.dataset.ciwiAppliedRate = String(rate);
 }


### PR DESCRIPTION
为 CustomLiquidTextTranslate 增加属性值与 shadow root 扫描，让 header-text 这类 web component 文案也能命中翻译并覆盖动态更新场景。