### PR TITLE
feat: open the credits modal from quota-blocked actions

### DIFF
--- a/app/api/translateV4Client.ts
+++ b/app/api/translateV4Client.ts
@@ -2,6 +2,9 @@ import {
   getTranslateV4ErrorDefaultMessage,
   TRANSLATE_V4_ERROR_KEYS,
 } from "~/utils/translateV4Errors";
+import { openCreditsPurchaseModal } from "~/utils/creditsPurchaseModal";
+
+const SINGLE_TRANSLATE_NO_CREDITS_ERROR = "v4.create.noCreditsPricing";
 
 type SingleTextTranslateArgs = {
   shopName: string;
@@ -24,6 +27,14 @@ export const SingleTextTranslate = async (args: SingleTextTranslateArgs) => {
       body: JSON.stringify({ ...args, customPrompt }),
     });
     const data = await res.json();
+    const rawErrorKey =
+      typeof data?.errorMsg === "string" ? data.errorMsg : undefined;
+    const quotaBlocked = rawErrorKey === SINGLE_TRANSLATE_NO_CREDITS_ERROR;
+
+    if (quotaBlocked) {
+      openCreditsPurchaseModal();
+    }
+
     if (!data?.success && data?.errorMsg) {
       const errorMsg = String(data.errorMsg).trim();
       if (errorMsg.startsWith("v4.")) {
@@ -31,13 +42,21 @@ export const SingleTextTranslate = async (args: SingleTextTranslateArgs) => {
       }
       return {
         ...data,
+        errorKey: rawErrorKey,
+        quotaBlocked,
+        status: res.status,
         errorMsg: getTranslateV4ErrorDefaultMessage(
           errorMsg,
           TRANSLATE_V4_ERROR_KEYS.SINGLE_TRANSLATE_FAILED,
         ),
       };
     }
-    return data;
+    return {
+      ...data,
+      errorKey: rawErrorKey,
+      quotaBlocked,
+      status: res.status,
+    };
   } catch (error) {
     console.error("Error SingleTextTranslate:", error);
     return {

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -26,10 +26,9 @@ import { resolveBillingBinding } from "~/server/billing/index.server";
 import { scheduleTsfWelcomeEmail } from "~/server/billing/email/welcomeEmail.server";
 import { enqueueShopScan } from "~/server/shopScan/trigger.server";
 import { loadShopLocalesForTranslation } from "~/server/translateV4/shopLocales.server";
-import { Suspense, lazy, useEffect, useState } from "react";
+import { Profiler, Suspense, lazy, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useIdleReady } from "~/hooks/useIdleReady";
-import { Profiler } from "react";
 
 import { ConfigProvider } from "antd";
 import { useDispatch } from "react-redux";
@@ -55,6 +54,7 @@ import {
   markPerfEnd,
   markPerfStart,
 } from "~/utils/perf";
+import { OPEN_CREDITS_PURCHASE_MODAL_EVENT } from "~/utils/creditsPurchaseModal";
 
 export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
@@ -63,6 +63,7 @@ const LazySupportChatWidget = lazy(() =>
     default: module.SupportChatWidget,
   })),
 );
+const LazyPaymentModal = lazy(() => import("~/components/paymentModal"));
 
 type AppBootstrapLocales = {
   source: { code: string; name: string };
@@ -460,6 +461,7 @@ export default function App() {
     useLoaderData<typeof loader>();
   const [isClient, setIsClient] = useState(false);
   const supportChatReady = useIdleReady();
+  const [showPaymentModal, setShowPaymentModal] = useState(false);
   const [perfDebugEnabled, setPerfDebugEnabled] = useState(perfDebug);
 
   const { t } = useTranslation();
@@ -521,6 +523,26 @@ export default function App() {
     };
   }, [bootstrap, dispatch, shop]);
 
+  useEffect(() => {
+    if (!isClient) return;
+
+    const handleOpenCreditsPurchaseModal = () => {
+      setShowPaymentModal(true);
+    };
+
+    window.addEventListener(
+      OPEN_CREDITS_PURCHASE_MODAL_EVENT,
+      handleOpenCreditsPurchaseModal,
+    );
+
+    return () => {
+      window.removeEventListener(
+        OPEN_CREDITS_PURCHASE_MODAL_EVENT,
+        handleOpenCreditsPurchaseModal,
+      );
+    };
+  }, [isClient]);
+
   return (
     <AppProvider isEmbeddedApp apiKey={apiKey}>
       <ConfigProvider
@@ -563,6 +585,14 @@ export default function App() {
           </NavMenu>
           <Outlet />
         </Profiler>
+        {isClient && showPaymentModal ? (
+          <Suspense fallback={null}>
+            <LazyPaymentModal
+              visible={showPaymentModal}
+              setVisible={setShowPaymentModal}
+            />
+          </Suspense>
+        ) : null}
         {isClient && supportChatReady ? (
           <Suspense fallback={null}>
             <LazySupportChatWidget />

--- a/app/utils/creditsPurchaseModal.ts
+++ b/app/utils/creditsPurchaseModal.ts
@@ -1,0 +1,7 @@
+export const OPEN_CREDITS_PURCHASE_MODAL_EVENT =
+  "ciwi:open-credits-purchase-modal";
+
+export function openCreditsPurchaseModal() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(OPEN_CREDITS_PURCHASE_MODAL_EVENT));
+}


### PR DESCRIPTION
Dispatch a shared credits-purchase event when single-translation requests hit the no-credits state, and let the app shell open the purchase modal in place.