### PR TITLE
refactor: unify credit purchase modal UI

### DIFF
--- a/app/components/V4ModalShell.tsx
+++ b/app/components/V4ModalShell.tsx
@@ -1,0 +1,121 @@
+import { useEffect } from "react";
+import type { CSSProperties, ReactNode } from "react";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  width?: number;
+  maxHeight?: string;
+  panelStyle?: CSSProperties;
+  disableClose?: boolean;
+  showCloseButton?: boolean;
+};
+
+export function V4ModalShell({
+  open,
+  onClose,
+  children,
+  width = 720,
+  maxHeight = "min(820px, calc(100vh - 32px))",
+  panelStyle,
+  disableClose = false,
+  showCloseButton = true,
+}: Props) {
+  useEffect(() => {
+    if (!open) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !disableClose) {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onClose, disableClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      aria-modal="true"
+      role="dialog"
+      style={overlayStyle}
+      onClick={() => {
+        if (!disableClose) onClose();
+      }}
+    >
+      <div
+        style={{
+          ...panelStyleBase,
+          width: `min(${width}px, calc(100vw - 32px))`,
+          maxHeight,
+          ...panelStyle,
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {showCloseButton ? (
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            disabled={disableClose}
+            style={closeButtonStyle}
+          >
+            ×
+          </button>
+        ) : null}
+        {children}
+      </div>
+    </div>
+  );
+}
+
+const overlayStyle: CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  zIndex: 2147483100,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 16,
+  background: "rgba(15, 23, 42, 0.36)",
+  backdropFilter: "blur(8px)",
+};
+
+const panelStyleBase: CSSProperties = {
+  position: "relative",
+  overflow: "hidden",
+  borderRadius: 20,
+  border: "1px solid var(--app-color-border-secondary)",
+  background: "var(--app-color-surface)",
+  boxShadow: "var(--app-shadow-card-strong)",
+  display: "flex",
+  flexDirection: "column",
+};
+
+const closeButtonStyle: CSSProperties = {
+  position: "absolute",
+  top: 14,
+  right: 14,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 32,
+  height: 32,
+  padding: 0,
+  border: "none",
+  borderRadius: 999,
+  background: "rgba(15, 23, 42, 0.04)",
+  color: "var(--app-color-text-secondary)",
+  fontSize: 20,
+  lineHeight: 1,
+  cursor: "pointer",
+};

--- a/app/components/paymentModal.shared.ts
+++ b/app/components/paymentModal.shared.ts
@@ -1,0 +1,58 @@
+export interface OptionType {
+  key: string;
+  name: string;
+  Credits: number;
+  price: {
+    currentPrice: number;
+    comparedPrice: number;
+    currencyCode: string;
+  };
+}
+
+type PackDefinition = {
+  key: string;
+  name: string;
+  credits: number;
+  fullPrice: number;
+};
+
+const PACK_DEFINITIONS: PackDefinition[] = [
+  { key: "option-1", name: "500K", credits: 500000, fullPrice: 3.99 },
+  { key: "option-2", name: "1M", credits: 1000000, fullPrice: 7.99 },
+  { key: "option-3", name: "2M", credits: 2000000, fullPrice: 15.99 },
+  { key: "option-4", name: "3M", credits: 3000000, fullPrice: 23.99 },
+  { key: "option-5", name: "5M", credits: 5000000, fullPrice: 39.99 },
+  { key: "option-6", name: "10M", credits: 10000000, fullPrice: 79.99 },
+  { key: "option-7", name: "20M", credits: 20000000, fullPrice: 159.99 },
+  { key: "option-8", name: "30M", credits: 30000000, fullPrice: 239.99 },
+];
+
+export function buildPaymentOptions(plan: any): OptionType[] {
+  return PACK_DEFINITIONS.map((pack) => ({
+    key: pack.key,
+    name: pack.name,
+    Credits: pack.credits,
+    price: {
+      currentPrice: getDiscountedPrice(pack.fullPrice, plan),
+      comparedPrice: pack.fullPrice,
+      currencyCode: "USD",
+    },
+  }));
+}
+
+function getDiscountedPrice(fullPrice: number, plan: any): number {
+  if (plan?.isInFreePlanTime) {
+    return fullPrice;
+  }
+
+  const discountRatio =
+    plan?.type === "Premium"
+      ? 0.5
+      : plan?.type === "Pro"
+        ? 0.75
+        : plan?.type === "Basic"
+          ? 0.9
+          : 1;
+
+  return Math.floor(fullPrice * discountRatio * 100) / 100;
+}

--- a/app/components/paymentModal.tsx
+++ b/app/components/paymentModal.tsx
@@ -1,39 +1,26 @@
 import {
-  Divider,
-  Modal,
-  Space,
-  Typography,
-} from "antd";
+  Button as PolarisButton,
+  InlineStack,
+  Link as PolarisLink,
+  Select as PolarisSelect,
+  Text as PolarisText,
+} from "@shopify/polaris";
 import { useEffect, useMemo, useState } from "react";
-import PaymentOptionSelect from "./paymentOptionSelect";
 import { useFetcher } from "@remix-run/react";
 import { useTranslation } from "react-i18next";
 import { handleContactSupport } from "~/utils/supportChat";
 import { useSelector } from "react-redux";
 import useReport from "../../scripts/eventReport";
 import "./styles.css";
-import { v4CardStyle, v4Colors } from "~/routes/app.translate-v4/v4Styles";
-import Button from "~/ui/components/AppButton";
-
-const { Title, Text } = Typography;
+import { v4Colors } from "~/routes/app.translate-v4/v4Styles";
+import { V4ModalShell } from "~/components/V4ModalShell";
+import { buildPaymentOptions, type OptionType } from "./paymentModal.shared";
 
 interface PaymentModalProps {
   visible: boolean;
   setVisible: (visible: boolean) => void;
   variant?: "default" | "v4";
 }
-
-export interface OptionType {
-  key: string;
-  name: string;
-  Credits: number;
-  price: {
-    currentPrice: number;
-    comparedPrice: number;
-    currencyCode: string;
-  };
-}
-
 const PaymentModal: React.FC<PaymentModalProps> = ({ visible, setVisible, variant = "default" }) => {
   const [selectedKey, setSelectedKey] = useState<string>("option-1");
   const [buyButtonLoading, setBuyButtonLoading] = useState<boolean>(false);
@@ -41,161 +28,22 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ visible, setVisible, varian
   const payFetcher = useFetcher<any>();
   const { reportClick } = useReport();
   const { plan } = useSelector((state: any) => state.userConfig);
-  const isV4 = variant === "v4";
+  void variant;
 
-  const options: OptionType[] = useMemo(
-    () => [
-      {
-        key: "option-1",
-        name: "500K",
-        Credits: 500000,
-        price: {
-          currentPrice: plan?.isInFreePlanTime
-            ? 3.99
-            : plan?.type === "Premium"
-              ? 1.99
-              : plan?.type === "Pro"
-                ? 2.99
-                : plan?.type === "Basic"
-                  ? 3.59
-                  : 3.99,
-          comparedPrice: 3.99,
-          currencyCode: "USD",
-        },
-      },
-      {
-        key: "option-2",
-        name: "1M",
-        Credits: 1000000,
-        price: {
-          currentPrice: plan?.isInFreePlanTime
-            ? 7.99
-            : plan?.type === "Premium"
-              ? 3.99
-              : plan?.type === "Pro"
-                ? 5.99
-                : plan?.type === "Basic"
-                  ? 7.19
-                  : 7.99,
-          comparedPrice: 7.99,
-          currencyCode: "USD",
-        },
-      },
-      {
-        key: "option-3",
-        name: "2M",
-        Credits: 2000000,
-        price: {
-          currentPrice: plan?.isInFreePlanTime
-            ? 15.99
-            : plan?.type === "Premium"
-              ? 7.99
-              : plan?.type === "Pro"
-                ? 11.99
-                : plan?.type === "Basic"
-                  ? 14.39
-                  : 15.99,
-          comparedPrice: 15.99,
-          currencyCode: "USD",
-        },
-      },
-      {
-        key: "option-4",
-        name: "3M",
-        Credits: 3000000,
-        price: {
-          currentPrice: plan?.isInFreePlanTime
-            ? 23.99
-            : plan?.type === "Premium"
-              ? 11.99
-              : plan?.type === "Pro"
-                ? 17.99
-                : plan?.type === "Basic"
-                  ? 21.79
-                  : 23.99,
-          comparedPrice: 23.99,
-          currencyCode: "USD",
-        },
-      },
-      {
-        key: "option-5",
-        name: "5M",
-        Credits: 5000000,
-        price: {
-          currentPrice: plan?.isInFreePlanTime
-            ? 39.99
-            : plan?.type === "Premium"
-              ? 19.99
-              : plan?.type === "Pro"
-                ? 29.99
-                : plan?.type === "Basic"
-                  ? 35.99
-                  : 39.99,
-          comparedPrice: 39.99,
-          currencyCode: "USD",
-        },
-      },
-      {
-        key: "option-6",
-        name: "10M",
-        Credits: 10000000,
-        price: {
-          currentPrice: plan?.isInFreePlanTime
-            ? 79.99
-            : plan?.type === "Premium"
-              ? 39.99
-              : plan?.type === "Pro"
-                ? 59.99
-                : plan?.type === "Basic"
-                  ? 71.99
-                  : 79.99,
-          comparedPrice: 79.99,
-          currencyCode: "USD",
-        },
-      },
-      {
-        key: "option-7",
-        name: "20M",
-        Credits: 20000000,
-        price: {
-          currentPrice: plan?.isInFreePlanTime
-            ? 159.99
-            : plan?.type === "Premium"
-              ? 79.99
-              : plan?.type === "Pro"
-                ? 119.99
-                : plan?.type === "Basic"
-                  ? 143.99
-                  : 159.99,
-          comparedPrice: 159.99,
-          currencyCode: "USD",
-        },
-      },
-      {
-        key: "option-8",
-        name: "30M",
-        Credits: 30000000,
-        price: {
-          currentPrice: plan?.isInFreePlanTime
-            ? 239.99
-            : plan?.type === "Premium"
-              ? 119.99
-              : plan?.type === "Pro"
-                ? 179.99
-                : plan?.type === "Basic"
-                  ? 215.99
-                  : 239.99,
-          comparedPrice: 239.99,
-          currencyCode: "USD",
-        },
-      },
-    ],
-    [plan],
-  );
+  const options: OptionType[] = useMemo(() => buildPaymentOptions(plan), [plan]);
 
   const selectedOption = useMemo(() => {
     return options.find((item) => item.key == selectedKey) || options[0];
   }, [selectedKey, options]);
+
+  const selectOptions = useMemo(
+    () =>
+      options.map((option) => ({
+        label: `${option.name} · ${Number(option.Credits).toLocaleString()} ${t("credits")}`,
+        value: option.key,
+      })),
+    [options, t],
+  );
 
   useEffect(() => {
     if (payFetcher.data) {
@@ -231,184 +79,101 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ visible, setVisible, varian
     // if (recommendOption) setSelectedOption(recommendOption);
   };
 
-  if (isV4) {
-    return (
-      <Modal
-        open={visible}
-        onCancel={onCancel}
-        width={960}
-        footer={null}
-        styles={{
-          content: {
-            padding: 0,
-            overflow: "hidden",
-            borderRadius: 20,
-            border: `1px solid ${v4Colors.cardBorder}`,
-            background: v4Colors.cardBg,
-            boxShadow: "var(--app-shadow-card-strong)",
-          },
-          body: {
-            padding: 0,
-          },
-        }}
-      >
-        <div style={{ padding: "24px 24px 20px" }}>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "flex-start",
-              gap: 16,
-              flexWrap: "wrap",
-              paddingBottom: 20,
-              marginBottom: 20,
-              borderBottom: `1px solid ${v4Colors.divider}`,
-            }}
-          >
-            <div style={{ minWidth: 0, flex: 1 }}>
-              <Text
-                strong
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  padding: "4px 10px",
-                  borderRadius: 999,
-                  background: v4Colors.primarySoft,
-                  color: v4Colors.primary,
-                  fontSize: 12,
-                  lineHeight: "20px",
-                  marginBottom: 12,
-                }}
-              >
-                {t("Translation credits")}
-              </Text>
-              <Title level={3} style={{ margin: 0, lineHeight: 1.25, color: v4Colors.text }}>
-                {t("Not enough translation credits. Purchase more to continue")}
-              </Title>
-              <Text
-                style={{
-                  display: "block",
-                  marginTop: 12,
-                  color: v4Colors.textMuted,
-                  fontSize: 14,
-                  lineHeight: "22px",
-                  maxWidth: 560,
-                }}
-              >
-                {t("Choose a credit pack to keep the current task queue moving without leaving the page.")}
-              </Text>
-            </div>
-
+  return (
+    <V4ModalShell open={visible} onClose={onCancel} width={560}>
+      <div style={{ padding: "24px 24px 20px" }}>
+        <div
+          style={{
+            paddingBottom: 20,
+            marginBottom: 20,
+            borderBottom: `1px solid ${v4Colors.divider}`,
+          }}
+        >
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <PolarisText as="h2" variant="headingLg" fontWeight="bold">
+              {t("Buy credits")}
+            </PolarisText>
             <div
               style={{
-                ...v4CardStyle,
-                background: v4Colors.summaryBg,
-                borderRadius: 16,
-                padding: "16px 18px",
-                minWidth: 220,
-                flex: "0 0 auto",
+                marginTop: 10,
               }}
             >
-              <Text
-                style={{
-                  display: "block",
-                  fontSize: 12,
-                  fontWeight: 600,
-                  color: v4Colors.textMuted,
-                  marginBottom: 8,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                {t("Selected pack")}
-              </Text>
-              <Text
-                strong
-                style={{
-                  display: "block",
-                  fontSize: 22,
-                  lineHeight: 1.1,
-                  color: v4Colors.text,
-                  marginBottom: 6,
-                }}
-              >
-                {selectedOption?.name ?? "500K"}
-              </Text>
-              <Text style={{ display: "block", color: v4Colors.textMuted, marginBottom: 12 }}>
-                {Number(selectedOption?.Credits ?? 0).toLocaleString()} {t("credits")}
-              </Text>
-              <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
-                <Text strong style={{ fontSize: 24, lineHeight: 1, color: v4Colors.text }}>
-                  ${selectedOption?.price.currentPrice ?? 0}
-                </Text>
-                <Text style={{ color: v4Colors.textMuted }}>{t("one-time")}</Text>
+              <PolarisText as="p" variant="bodyMd" tone="subdued">
+                {t("Choose a pack for this task.")}
+              </PolarisText>
+            </div>
+          </div>
+        </div>
+
+        <div style={{ marginBottom: 24 }}>
+          <PolarisSelect
+            label={t("Credit pack")}
+            labelHidden
+            options={selectOptions}
+            value={selectedKey}
+            onChange={setSelectedKey}
+          />
+          <div
+            style={{
+              marginTop: 14,
+              padding: "14px 16px",
+              borderRadius: 14,
+              border: `1px solid ${v4Colors.cardBorder}`,
+              background: v4Colors.cardBg,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 16,
+                flexWrap: "wrap",
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <PolarisText as="p" variant="bodySm" tone="subdued">
+                  {t("Credits")}
+                </PolarisText>
+                <div style={{ marginTop: 4 }}>
+                  <PolarisText as="p" variant="headingMd" fontWeight="bold">
+                    {selectedOption?.name}
+                  </PolarisText>
+                </div>
+                <div style={{ marginTop: 4 }}>
+                  <PolarisText as="p" variant="bodyMd" tone="subdued">
+                    {Number(selectedOption?.Credits ?? 0).toLocaleString()} {t("credits")}
+                  </PolarisText>
+                </div>
+              </div>
+              <div style={{ minWidth: 0, textAlign: "right" }}>
+                <PolarisText as="p" variant="bodySm" tone="subdued">
+                  {t("Total Payment:")}
+                </PolarisText>
+                <div style={{ marginTop: 4 }}>
+                  <PolarisText as="p" variant="headingMd" fontWeight="bold">
+                    ${selectedOption?.price.currentPrice.toFixed(2) ?? "0.00"}
+                  </PolarisText>
+                </div>
               </div>
             </div>
           </div>
+        </div>
 
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
-              gap: 12,
-              marginBottom: 20,
-            }}
-          >
-            {options.map((option) => (
-              <PaymentOptionSelect
-                key={option.key}
-                option={option}
-                selectedOption={selectedOption}
-                onChange={(value) => setSelectedKey(value.key)}
-                variant="v4"
-              />
-            ))}
-          </div>
-
-          <div
-            style={{
-              ...v4CardStyle,
-              background: v4Colors.cardSubdued,
-              borderRadius: 16,
-              padding: "16px 18px",
-              marginBottom: 20,
-              display: "flex",
-              justifyContent: "space-between",
-              gap: 16,
-              alignItems: "center",
-              flexWrap: "wrap",
-            }}
-          >
-            <div>
-              <Text
-                style={{
-                  display: "block",
-                  fontSize: 12,
-                  fontWeight: 600,
-                  color: v4Colors.textMuted,
-                  marginBottom: 6,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                {t("Need help deciding?")}
-              </Text>
-              <Text style={{ color: v4Colors.textMuted, lineHeight: "22px" }}>
-                {t("Contact support if you need help estimating the right credit pack.")}
-              </Text>
-            </div>
-            <Button
-              type="default"
-              onClick={handleContactSupport}
-              style={{
-                borderColor: v4Colors.cardBorder,
-                color: v4Colors.text,
-              }}
-            >
-              {t("Contact support")}
-            </Button>
-          </div>
-
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 12,
+            flexWrap: "wrap",
+          }}
+        >
+          <InlineStack gap="100" align="center">
+            <PolarisText as="span" variant="bodyMd" tone="subdued">
+              {t("Need help?")}
+            </PolarisText>
+            <PolarisLink onClick={handleContactSupport}>{t("Contact us")}</PolarisLink>
+          </InlineStack>
           <div
             style={{
               display: "flex",
@@ -417,189 +182,29 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ visible, setVisible, varian
               flexWrap: "wrap",
             }}
           >
-            <Button
-              onClick={onCancel}
-              style={{
-                minWidth: 108,
-                borderColor: v4Colors.cardBorder,
-              }}
-            >
-              {t("Maybe later")}
-            </Button>
-            <Button
-              type="primary"
-              onClick={onClick}
-              disabled={buyButtonLoading || !selectedKey}
-              loading={buyButtonLoading}
-              style={{
-                minWidth: 160,
-                height: "auto",
-                paddingBlock: 8,
-              }}
-            >
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  lineHeight: 1.25,
-                }}
-              >
-                <Text strong style={{ color: "inherit" }}>
-                  ${selectedOption?.price.currentPrice ?? 0}
-                </Text>
-                <Text style={{ color: "inherit" }}>
-                  {t("Buy now")}
-                </Text>
-              </div>
-            </Button>
-          </div>
-        </div>
-      </Modal>
-    );
-  }
-
-  return (
-    <Modal
-      open={visible}
-      onCancel={onCancel}
-      width={1000}
-      footer={[
-        <div
-          key="footer-container"
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "flex-end",
-          }}
-        >
-          <div key="support-section">
-            <Text strong key="cost-question">
-              {t("Cost questions: ")}
-            </Text>
-            <Button
-              key="contact-support"
-              type="link"
-              onClick={handleContactSupport}
-              style={{ marginLeft: "-15px" }}
-            >
-              {t("Contact support")}
-            </Button>
-          </div>
-          <Button
-            key="buy-now"
-            type="primary"
-            onClick={onClick}
-            disabled={buyButtonLoading || !selectedKey}
-            loading={buyButtonLoading}
-            style={{
-              height: "auto",
-              paddingTop: "4px",
-              paddingBottom: "4px",
-            }}
-          >
-            <div
-              key="button-content"
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-              }}
-            >
-              <Text key="price" strong style={{ color: "inherit" }}>
-                ${selectedOption?.price.currentPrice ?? 0}
-              </Text>
-              <Text key="buy-text" style={{ color: "inherit" }}>
-                {t("Buy now")}
-              </Text>
+            <div style={{ minWidth: 124 }}>
+              <PolarisButton fullWidth size="large" variant="secondary" onClick={onCancel}>
+                {t("Maybe later")}
+              </PolarisButton>
             </div>
-          </Button>
-        </div>,
-      ]}
-    >
-      <Title level={4} style={{ textAlign: "center", marginTop: "20px" }}>
-        {t("Not enough translation credits. Purchase more to continue")}
-      </Title>
-      {/* <Card>
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
-          <Title level={5}>{t("Translation tasks")}</Title>
-          <Title level={5} style={{ marginTop: "0px" }}>{t("Credits to be consumed")}</Title>
-        </div>
-        <Divider style={{ margin: "10px 0" }} />
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
-          <div>
-            <Text strong>{t("Estimated number of words to translate: ")}</Text>
-            {credits === undefined ? <Text strong>{t("Calculating...")}</Text> : credits >= 0 ? <Text strong>{credits.toLocaleString()} {t("words")}</Text> : <Text strong>{t("Calculation failed")}</Text>}
-          </div>
-          {credits === undefined ? <Text strong>{t("Calculating...")}</Text> : credits >= 0 ? <Text strong>{credits.toLocaleString()}</Text> : <Text strong>{t("Calculation failed")}</Text>}
-        </div>
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
-          <div>
-            <Text strong>{t("Translate files: ")}</Text>
-            <Text strong>{source.toUpperCase()} {t("translate to")} {target.toUpperCase()}</Text>
-          </div>
-          <Text strong>*{multiple1}</Text>
-        </div>
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
-          <div>
-            <Text strong>{t("Translate modal: ")}</Text>
-            <Text strong>{model.label}</Text>
-          </div>
-          <Text strong>*{multiple2}</Text>
-        </div>
-        <Divider style={{ margin: "10px 0" }} />
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
-          <div>
-            <Text strong>{t("Total: ")}</Text>
-          </div>
-          <Text strong> {credits === undefined ? <Text strong>{t("Calculating...")}</Text> : credits >= 0 ? <Text strong>{Number((credits * multiple1 * multiple2).toFixed(0)).toLocaleString()}</Text> : <Text strong>{t("Calculation failed")}</Text>}</Text>
-        </div>
-      </Card> */}
-
-      <Divider />
-      <Title level={5}>{t("Buy credits")}</Title>
-      <div className="options_wrapper">
-        <Space direction="vertical">
-          <div
-            style={{
-              display: "flex",
-              flexWrap: "wrap", // 允许自动换行
-              gap: "16px",
-              width: "100%",
-            }}
-          >
-            {options.map((option: any) => (
-              <div
-                key={option.name}
-                style={{
-                  flex: "0 1 auto", // 允许缩小但不放大
-                  // minWidth: '200px',  // 设置最小宽度
-                  display: "flex",
-                  justifyContent: "center",
-                }}
+            <div style={{ minWidth: 180 }}>
+              <PolarisButton
+                fullWidth
+                size="large"
+                variant="primary"
+                onClick={onClick}
+                disabled={buyButtonLoading || !selectedKey}
+                loading={buyButtonLoading}
               >
-                <PaymentOptionSelect
-                  option={option}
-                  selectedOption={selectedOption}
-                  onChange={(e) => setSelectedKey(e.key)}
-                />
-              </div>
-            ))}
+                {t("Buy now")} · ${selectedOption?.price.currentPrice ?? 0}
+              </PolarisButton>
+            </div>
           </div>
-        </Space>
+        </div>
       </div>
-      <Divider />
-      <div className="total_payment">
-        <Text style={{ marginRight: "5px" }}>{t("Total Payment:")}</Text>
-        <Text strong>
-          $
-          {selectedOption?.price.currentPrice
-            ? selectedOption?.price.currentPrice
-            : 0}
-        </Text>
-      </div>
-    </Modal>
+    </V4ModalShell>
   );
 };
 
 export default PaymentModal;
+export type { OptionType } from "./paymentModal.shared";

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1003,5 +1003,9 @@
   "Your store's default language:": "Your store's default language:",
   "Your translation quota": "Your Translation Balance",
   "Youthful": "Youthful",
-  "Zara – Modern & chic (Womenswear)": "Zara – Modern & chic (Womenswear)"
+  "Zara – Modern & chic (Womenswear)": "Zara – Modern & chic (Womenswear)",
+  "Credit pack": "Credit pack",
+  "Choose a pack for this task.": "Choose a pack for this task.",
+  "Need help?": "Need help?",
+  "Contact us": "Contact us"
 }

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -1006,5 +1006,9 @@
   "Your store's default language:": "您商店的默认语言：",
   "Your translation quota": "您的翻译额度",
   "Youthful": "年轻 —— 活泼、时尚感",
-  "Zara – Modern & chic (Womenswear)": "Zara：摩登时髦（女装）"
+  "Zara – Modern & chic (Womenswear)": "Zara：摩登时髦（女装）",
+  "Credit pack": "积分包",
+  "Choose a pack for this task.": "为当前任务选择积分包。",
+  "Need help?": "需要帮助？",
+  "Contact us": "联系我们"
 }


### PR DESCRIPTION
Replace the old card-based credit modal with a shared shell and dropdown pack selector so storefront and v4 purchase flows use the same 560px layout and option catalog.