### PR TITLE
性能优化: Session索引 / Worker模块计数并行化 / 翻译核心正则热路径

### DIFF
--- a/packages/translation-core/src/llmTranslate.ts
+++ b/packages/translation-core/src/llmTranslate.ts
@@ -541,9 +541,23 @@ function langPrefix(locale: string): string {
   return locale.toLowerCase().split(/[-_]/)[0] || "";
 }
 
+/**
+ * All script-detection regexes above are module-level consts without the "g"
+ * flag, so this always hit the `new RegExp(re.source, flags)` branch — i.e. a
+ * fresh RegExp was compiled from source on every call, and this runs once per
+ * field per script check inside meetsScriptThreshold (hot path: "already in
+ * target language" skip-check, evaluated per field). Cache the global-flag
+ * clone per source RegExp object instead of rebuilding it every call.
+ */
+const globalRegexCache = new WeakMap<RegExp, RegExp>();
 function countRegexMatches(text: string, re: RegExp): number {
-  const flags = re.flags.includes("g") ? re.flags : `${re.flags}g`;
-  return [...text.matchAll(new RegExp(re.source, flags))].length;
+  let globalRe = globalRegexCache.get(re);
+  if (!globalRe) {
+    const flags = re.flags.includes("g") ? re.flags : `${re.flags}g`;
+    globalRe = re.flags.includes("g") ? re : new RegExp(re.source, flags);
+    globalRegexCache.set(re, globalRe);
+  }
+  return [...text.matchAll(globalRe)].length;
 }
 
 function countMeaningfulChars(text: string): number {

--- a/packages/translation-core/src/placeholderMask.ts
+++ b/packages/translation-core/src/placeholderMask.ts
@@ -38,23 +38,24 @@ function restorePlaceholders(text: string, tokens: string[]): string {
   return text.replace(SENT_RE, (_m, d: string) => tokens[Number(d)] ?? "");
 }
 
-/** Recover common LLM corruptions of ⟦n⟧ (e.g. [number]0[number]) before giving up. */
+/**
+ * Recover common LLM corruptions of ⟦n⟧ (e.g. [number]0[number]) before giving up.
+ * Previously built 3 separate RegExp objects per token and ran test()+replace()
+ * (two full-string scans) for each, i.e. up to 6 scans per token. A single
+ * combined alternation regex does it in one construction + one scan per token,
+ * and — unlike the old "stop at first matching pattern type" logic — also
+ * fixes any corruption type present, not just the first one tried.
+ */
 function restorePlaceholdersLenient(text: string, tokens: string[]): string {
   let out = text;
   for (let i = 0; i < tokens.length; i++) {
     const sentinel = `${SENT_OPEN}${i}${SENT_CLOSE}`;
     if (out.includes(sentinel)) continue;
-    const corruptPatterns = [
-      new RegExp(`\\[number\\]${i}\\[number\\]`, "gi"),
-      new RegExp(`\\[${i}\\]`, "g"),
-      new RegExp(`\\{${i}\\}`, "g"),
-    ];
-    for (const re of corruptPatterns) {
-      if (re.test(out)) {
-        out = out.replace(re, tokens[i] ?? sentinel);
-        break;
-      }
-    }
+    const combined = new RegExp(
+      `\\[number\\]${i}\\[number\\]|\\[${i}\\]|\\{${i}\\}`,
+      "gi",
+    );
+    out = out.replace(combined, tokens[i] ?? sentinel);
   }
   return out;
 }

--- a/prisma/migrations/20260818000000_session_shop_isonline_index/migration.sql
+++ b/prisma/migrations/20260818000000_session_shop_isonline_index/migration.sql
@@ -1,0 +1,6 @@
+-- Session has no index today, but every Shopify Admin API call (App + Worker)
+-- resolves the offline token via `WHERE shop = ? AND isOnline = 0` with no
+-- process-level cache (shopAccessToken.ts / offlineSessionToken.server.ts).
+-- This is the hottest read path in the whole system and was doing a full
+-- table scan. Add a composite index to cover it.
+CREATE INDEX IF NOT EXISTS "Session_shop_isOnline_idx" ON "Session"("shop", "isOnline");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,11 @@ model Session {
   emailVerified       Boolean?  @default(false)
   refreshToken        String?
   refreshTokenExpires DateTime?
+
+  // 每次 Shopify Admin API 调用都会按 shop + isOnline 查 offline token（App 与 Worker 唯一
+  // token 来源，见 shopAccessToken.ts / offlineSessionToken.server.ts，无进程内缓存），
+  // 是全库最热的查询路径；此前该表没有任何索引，命中的是全表扫描。
+  @@index([shop, isOnline])
 }
 
 // 取代 Java `Translates` —— 每店一行的翻译配置

--- a/worker/src/services/finalizeJobAfterWriteback.ts
+++ b/worker/src/services/finalizeJobAfterWriteback.ts
@@ -31,6 +31,35 @@ export type FinalizeAfterWritebackInput = {
   stageTimings?: StageTimings | null;
 };
 
+/**
+ * `computeModuleCount` 没有自己的节流/退避（直接裸 fetch 分页），所以不能对
+ * 10-20 个 module 做无限制的 Promise.all（会瞬时打爆 Shopify 该店的 GraphQL
+ * cost bucket，换来更多 429）。用一个小的并发上限把「串行 10-20 次」换成
+ * 「批量 N 路并行」，兼顾提速和不触发限流。
+ */
+const MODULE_COUNT_CONCURRENCY = 4;
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= items.length) return;
+        results[i] = await fn(items[i], i);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
 /** 写回结束后直接收尾：COMPLETED / PAUSED / FAILED（不再进入校验）。 */
 export async function finalizeJobAfterWriteback(
   job: TranslationV4Job,
@@ -85,28 +114,45 @@ export async function finalizeJobAfterWriteback(
     const modulesToCount = [
       ...new Set<string>([...job.modules, ...COVERAGE_SUMMARY_MODULES]),
     ];
-    for (const module of modulesToCount) {
-      if (!accessToken) break;
-      try {
-        const count = await computeModuleCount(
-          shopName,
-          accessToken,
-          module,
-          job.target,
-        );
-        moduleCounts.set(module, count);
-        const stored = await setItemsCount(shopName, job.target, module, count);
-        if (stored) {
-          console.log(
-            `[finalize] items_count job=${jobId} ${module} ${count.translated}/${count.total} stored`,
-          );
-        } else {
-          console.warn(
-            `[finalize] items_count job=${jobId} ${module} ${count.translated}/${count.total} redis unavailable`,
-          );
-        }
-      } catch (e) {
-        console.error(`[finalize] items_count job=${jobId} ${module} failed:`, e);
+    if (accessToken) {
+      const results = await mapWithConcurrency(
+        modulesToCount,
+        MODULE_COUNT_CONCURRENCY,
+        async (module) => {
+          try {
+            const count = await computeModuleCount(
+              shopName,
+              accessToken,
+              module,
+              job.target,
+            );
+            const stored = await setItemsCount(
+              shopName,
+              job.target,
+              module,
+              count,
+            );
+            if (stored) {
+              console.log(
+                `[finalize] items_count job=${jobId} ${module} ${count.translated}/${count.total} stored`,
+              );
+            } else {
+              console.warn(
+                `[finalize] items_count job=${jobId} ${module} ${count.translated}/${count.total} redis unavailable`,
+              );
+            }
+            return { module, count };
+          } catch (e) {
+            console.error(
+              `[finalize] items_count job=${jobId} ${module} failed:`,
+              e,
+            );
+            return null;
+          }
+        },
+      );
+      for (const r of results) {
+        if (r) moduleCounts.set(r.module, r.count);
       }
     }
 


### PR DESCRIPTION
## 改动说明

本次针对项目审查发现的3项高影响性能问题做修复：

### 1. `Session(shop, isOnline)` 补索引
`prisma/schema.prisma` + 新迁移 `20260818000000_session_shop_isonline_index`

App 和 Worker 每次 Shopify Admin API 调用都要走 `WHERE shop = ? AND isOnline = 0` 查 offline token（`shopAccessToken.ts` / `offlineSessionToken.server.ts`，按设计无进程内缓存），是全库最热的查询路径，但 `Session` 表此前没有任何索引，等于每次都全表扫描。

### 2. Worker 收尾阶段模块计数改为限流并行
`worker/src/services/finalizeJobAfterWriteback.ts`

任务写回完成后，`finalize` 阶段要对 10-20 个 module 逐个调用 Shopify GraphQL 统计已译/总数，原来是严格串行 `for...await`，单次收尾可能阻塞 5-40 秒。改为并发上限 4 的并行执行（`computeModuleCount` 本身没有节流退避逻辑，未加限制的 `Promise.all` 有打爆该店 Shopify GraphQL cost bucket 导致更多 429 的风险，因此用小并发池而非无限并行）。

### 3. 翻译核心引擎正则热路径优化
`packages/translation-core/src/{placeholderMask,llmTranslate}.ts`

- `restorePlaceholdersLenient`：原来每个占位符都要构造 3 个正则并各 `test()+replace()`（最多 6 次全串扫描），改为单个组合正则一次扫描完成，语义等价（且修复了原逻辑「只处理第一种匹配到的损坏类型」的不一致）。
- `countRegexMatches`：脚本检测用的正则常量都没有 `g` 标志，导致每次调用都要 `new RegExp(re.source, ...)` 重新编译；这是「已在目标语言」跳过判定的高频调用路径（每字段每次都会走）。改用 `WeakMap` 按正则对象缓存 global 变体，只编译一次。

## 验证
- `npx prisma validate` ✅
- `npx prisma generate` ✅
- `npm run core:build`（translation-core）✅
- `npm run worker:build` ✅

## 待办 / 风险
- 迁移 SQL 还未跑到 Turso 测试库/生产库，需要单独执行 `npm run turso:migrate:test` / `npm run turso:migrate:prod`。
- 未改动 App/前端相关的其余审查发现（覆盖率刷新串行、轮询退避、Redis pipeline 等），如需要可以后续单独处理。
