### PR TITLE
feat(translate-v4-mvp): 独立合入 MVP 翻译工作台（P0）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,11 +220,14 @@ and embedded `/app` redirect/landing behavior.
 
 ### Main Pages
 
-- `/app/translate-v4`: `app/routes/app.translate-v4/route.tsx`（只展示进行中 /
+- `/app`: `app/routes/app._index/route.tsx` 重定向到 `/app/translate-v4-mvp`（`getTranslatePagePath()` 同指向 MVP）。
+- `/app/translate-v4-mvp`: `app/routes/app.translate-v4-mvp/route.tsx`（推荐任务 + 覆盖率摘要 + 任务队列；复用 v4 确认弹窗 / TaskQueue / 预估）。
+- `/app/translate-v4-mvp-custom`: `app/routes/app.translate-v4-mvp-custom/route.tsx`（自定义语言/模块建任务）。
+- `/app/translate-v4`: `app/routes/app.translate-v4/route.tsx`（全量工作台保留；只展示进行中 /
 暂停 / 失败任务，见 `jobFilters.ts` `isCurrentV4Job`）。
 - `/app/translate-v4-history`: `app/routes/app.translate-v4-history/route.tsx`
-（终态任务历史；无导航入口，由 `TaskQueueSection.tsx` 的「历史」按钮跳入；复用
-`CompactJobCard` + `isHistoryV4Job` + `/api/translate-v4/task-action`）。
+（终态任务历史；无导航入口，由 `TaskQueueSection.tsx` 的「历史」按钮跳入；支持
+`?returnTo=` 回跳；复用 `CompactJobCard` + `isHistoryV4Job` + `/api/translate-v4/task-action`）。
 - `/app/language`: `app/routes/app.language/route.tsx`.
 - `/app/manage_translation`: `app/routes/app.manage_translation/route.tsx`.
 - `/app/manage_translation/<module>`: `app/routes/app.manage_translation_.*/route.tsx`.
@@ -234,7 +237,7 @@ and embedded `/app` redirect/landing behavior.
 - `/app/pricing`: `app/routes/app.pricing/route.tsx`.
 - `/app/shop-profile`: `app/routes/app.shop-profile/route.tsx`; nav is hidden in production.
 - `/app/onboarding`: `app/routes/app.onboarding/route.tsx`; 首次翻译新手引导（无导航入口，
-由 `/app` 条件重定向进入）。
+仍可显式访问 `/app/onboarding`）。
 - Treat an `app/routes/app.*` directory without a route file as inactive until a
 real `route.tsx` or route module is added.
 
@@ -1047,10 +1050,10 @@ Core files:
   `app/routes/api.onboarding.fast-coverage.ts`（Preparing 真进度：最重要 1 语 ×
   Products/Collection/Navigation/Pages/Shop 五个模块，逐 label POST；只写 Redis
   module 明细，**不**写 Turso 语言级汇总，避免污染权威覆盖率）。
-- 入口重定向: `app/routes/app._index/route.tsx` 调 `shouldRedirectToOnboarding`
-  决定跳 `/app/onboarding` 还是默认 `/app/translate-v4`；并在重定向前
-  `enqueueShopScan(install)`（幂等，尽早入队）。onboarding loader / `app.tsx` 也会
-  再入队一次（幂等）。
+- 入口重定向: `app/routes/app._index/route.tsx` 当前直接跳
+  `/app/translate-v4-mvp`；首次引导不再自动拦截 `/app`，仍可显式访问
+  `/app/onboarding`。install shop scan 继续由 `app.tsx` / onboarding loader
+  幂等入队。
 - Model: `ShopOnboarding`（每店一行，独立于 `Account.isNew`）。
 
 Data reuse（不重复建设）:

--- a/app/lib/translateNavigation.ts
+++ b/app/lib/translateNavigation.ts
@@ -1,4 +1,4 @@
-/** 批量翻译页路径（全量 v4）。 */
+/** 批量翻译页路径（新版 MVP 工作台）。 */
 export function getTranslatePagePath(): string {
-  return "/app/translate-v4";
+  return "/app/translate-v4-mvp";
 }

--- a/app/routes/app._index/route.tsx
+++ b/app/routes/app._index/route.tsx
@@ -1,8 +1,18 @@
-// `/app` 直接渲染翻译页，不再 302 到 `/app/translate-v4`：那一跳会把 app.tsx 的
-// loader 完整跑一遍（鉴权 + Shopify 语言查询）再把结果丢弃，纯浪费一个文档往返。
-// `/app/translate-v4` 保留为别名。
-// 新手引导已暂时关闭；新安装用户直接进入翻译首页。
-//
-// 页面 loader 已不再二次鉴权/拉语言：父级 `app.tsx` 统一提供 `shopLocales`，
-// 本文件只 re-export translate-v4 的轻量 loader + 页面组件。
-export { default, loader } from "../app.translate-v4/route";
+import { redirect, type LoaderFunctionArgs } from "@remix-run/node";
+import { authenticate } from "~/shopify.server";
+import { enqueueShopScan } from "~/server/shopScan/trigger.server";
+import { withEmbeddedSearch } from "~/utils/embeddedAction";
+
+/** `/app` 首页统一进入新版 MVP 翻译工作台。 */
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+
+  // 尽早入队 install 计量扫描（幂等）。
+  void enqueueShopScan({ shop: session.shop, trigger: "install" }).catch(
+    (err) => {
+      console.error("[app._index] early install scan enqueue failed:", err);
+    },
+  );
+
+  return redirect(withEmbeddedSearch("/app/translate-v4-mvp", new URL(request.url).search));
+};

--- a/app/routes/app.translate-v4-history/route.tsx
+++ b/app/routes/app.translate-v4-history/route.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TitleBar } from "@shopify/app-bridge-react";
 import { json, type LoaderFunctionArgs } from "@remix-run/node";
-import { useLoaderData, useNavigate } from "@remix-run/react";
-import { Button, Page, Text } from "@shopify/polaris";
+import { useLoaderData, useNavigate, useSearchParams } from "@remix-run/react";
+import { BlockStack, Button, Page, Text } from "@shopify/polaris";
 import { useTranslation } from "react-i18next";
 import AppPageHeader from "~/ui/components/AppPageHeader";
 import { message } from "~/ui/message";
@@ -45,6 +45,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 export default function AppTranslateV4History() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { shop, jobs: initialJobs } = useLoaderData<typeof loader>();
   const [jobs, setJobs] = useState<TranslationJobProgressSummary[]>(initialJobs);
   const [quota, setQuota] = useState<ShopQuota | null>(null);
@@ -52,6 +53,13 @@ export default function AppTranslateV4History() {
   const normalizedQuota = useMemo(() => normalizeShopQuota(quota), [quota]);
 
   const historyJobs = useMemo(() => jobs.filter(isHistoryV4Job), [jobs]);
+  const returnTo = useMemo(() => {
+    const value = searchParams.get("returnTo");
+    if (!value || !value.startsWith("/app/")) {
+      return "/app/translate-v4-mvp?tab=queue";
+    }
+    return value;
+  }, [searchParams]);
 
   const refreshList = useCallback(async () => {
     const res = await fetch(
@@ -151,19 +159,22 @@ export default function AppTranslateV4History() {
       />
       <Page>
         <div style={v4ContentStyle}>
-          <AppPageHeader
-            style={{ marginBottom: 18 }}
-            title={t("v4.tasks.historyPageTitle", { count: historyJobs.length })}
-            description={t("v4.tasks.historyHelper")}
-            extra={
+          <BlockStack gap="200">
+            <div>
               <Button
                 variant="plain"
-                onClick={() => navigate("/app/translate-v4")}
+                size="slim"
+                onClick={() => navigate(returnTo)}
               >
-                {t("v4.tasks.backToCurrent")}
+                {t("v4.back")}
               </Button>
-            }
-          />
+            </div>
+            <AppPageHeader
+              style={{ marginBottom: 18 }}
+              title={t("v4.tasks.historyPageTitle", { count: historyJobs.length })}
+              description={t("v4.tasks.historyHelper")}
+            />
+          </BlockStack>
 
           <div style={{ ...v4CardStyle, padding: "16px" }}>
             {historyJobs.length === 0 ? (

--- a/app/routes/app.translate-v4-mvp-custom/route.tsx
+++ b/app/routes/app.translate-v4-mvp-custom/route.tsx
@@ -197,7 +197,6 @@ export default function TranslateV4MvpCustomRoute() {
           ? "insufficient_trial"
           : "insufficient_pricing"
       : "ready";
-  const shouldSkipCreateConfirm = (remainingCredits ?? 0) > 30_000;
 
   const persistCreateTaskDraft = useCallback(() => {
     saveCreateTaskDraft(shop, {
@@ -376,12 +375,8 @@ export default function TranslateV4MvpCustomRoute() {
       );
       return;
     }
-    if (shouldSkipCreateConfirm) {
-      void handleCreateConfirm();
-      return;
-    }
     setCreateConfirmOpen(true);
-  }, [createQuotaGatePending, handleCreateConfirm, shouldSkipCreateConfirm, t]);
+  }, [createQuotaGatePending, t]);
 
   return (
     <Page>

--- a/app/routes/app.translate-v4-mvp-custom/route.tsx
+++ b/app/routes/app.translate-v4-mvp-custom/route.tsx
@@ -1,0 +1,463 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData, useLocation, useNavigate, useSearchParams } from "@remix-run/react";
+import { TitleBar } from "@shopify/app-bridge-react";
+import { BlockStack, Button, Page, Text } from "@shopify/polaris";
+import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import { message } from "~/ui/message";
+import { authenticate } from "~/shopify.server";
+import type { RootState } from "~/store";
+import { loadShopLocalesForTranslation } from "~/server/translateV4/shopLocales.server";
+import type { CoverageSummary } from "~/server/translateV4/coverage.server";
+import {
+  AI_MODEL_OPTIONS,
+  DEFAULT_AI_MODEL,
+  DEFAULT_MODULE_KEYS,
+} from "~/routes/app.translate-v4/constants";
+import {
+  buildUntranslatedRatioByLocale,
+  useCreateTaskEstimate,
+} from "~/routes/app.translate-v4/useCreateTaskEstimate";
+import { formatV4CreateTasksMessage, translateV4Message } from "~/routes/app.translate-v4/v4I18n";
+import { localeRegionCode } from "~/routes/app.translate-v4/localeDisplay";
+import { CreateTaskCard } from "~/routes/app.translate-v4/components/CreateTaskCard";
+import { CreateTaskConfirmModal } from "~/routes/app.translate-v4/components/CreateTaskConfirmModal";
+import { v4ContentStyle } from "~/routes/app.translate-v4/v4Styles";
+import { expandV2ModuleKeys } from "~/server/translateV4/moduleCatalog";
+import {
+  createTranslateV4Tasks,
+  type ShopLocaleOption,
+} from "~/lib/createTranslateV4Tasks";
+import { normalizeShopQuota, type ShopQuota } from "~/lib/translationQuota";
+import { shouldBlockCreateTaskByCredits } from "~/lib/createTranslateQuotaGuard";
+import { openCreditsPurchaseModal } from "~/utils/creditsPurchaseModal";
+import { buildCreateTaskCreditsPurchaseContext } from "~/utils/creditsPurchaseTaskContext";
+import {
+  clearCreateTaskDraft,
+  loadCreateTaskDraft,
+  saveCreateTaskDraft,
+} from "~/utils/createTaskDraft";
+import {
+  parseBillingReturn,
+  stripBillingReturnParams,
+} from "~/utils/billingReturn";
+
+const EMPTY_COVERAGE: CoverageSummary = {
+  languageCount: 0,
+  translatedItems: 0,
+  totalItems: 0,
+  overallPercent: null,
+  locales: [],
+};
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+
+  let locales: ShopLocaleOption[] = [];
+  let primaryLocale = "en";
+
+  try {
+    const loaded = await loadShopLocalesForTranslation({
+      shop: session.shop,
+      accessToken: session.accessToken as string,
+    });
+    locales = loaded.localeOptions;
+    primaryLocale = loaded.primaryLocale;
+  } catch (err) {
+    console.error("[translate-v4-mvp-custom] load locales failed:", err);
+  }
+
+  return json({
+    shop: session.shop,
+    locales,
+    primaryLocale,
+  });
+};
+
+async function readJsonResponse<T = unknown>(res: Response): Promise<T> {
+  const text = await res.text();
+  if (!text.trim()) {
+    throw new Error(`Empty response body (${res.status})`);
+  }
+  return JSON.parse(text) as T;
+}
+
+function parseListParam(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseBooleanParam(value: string | null): boolean {
+  return value === "1" || value === "true";
+}
+
+export default function TranslateV4MvpCustomRoute() {
+  const { t } = useTranslation();
+  const { shop, locales, primaryLocale } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const plan = useSelector((state: RootState) => state.userConfig.plan);
+  const isNew = useSelector((state: RootState) => state.userConfig.isNew);
+  const billingDraftRestoredRef = useRef(false);
+
+  const targetOptions = useMemo(
+    () =>
+      locales.filter((locale) => locale.value !== primaryLocale) as ShopLocaleOption[],
+    [locales, primaryLocale],
+  );
+
+  const validTargets = useMemo(
+    () => new Set(targetOptions.map((option) => option.value)),
+    [targetOptions],
+  );
+  const validModules = useMemo(() => new Set<string>(DEFAULT_MODULE_KEYS), []);
+
+  const initialTargets = useMemo(() => {
+    const parsed = parseListParam(searchParams.get("targets")).filter((item) =>
+      validTargets.has(item),
+    );
+    return parsed.length > 0 ? parsed : targetOptions.map((item) => item.value);
+  }, [searchParams, targetOptions, validTargets]);
+
+  const initialModules = useMemo(() => {
+    const parsed = parseListParam(searchParams.get("modules")).filter((item) =>
+      validModules.has(item),
+    );
+    return parsed.length > 0 ? parsed : DEFAULT_MODULE_KEYS;
+  }, [searchParams, validModules]);
+
+  const initialAiModel = useMemo(() => {
+    const value = searchParams.get("aiModel");
+    if (value && AI_MODEL_OPTIONS.some((item) => item.value === value)) {
+      return value;
+    }
+    return DEFAULT_AI_MODEL;
+  }, [searchParams]);
+
+  const [coverage, setCoverage] = useState<CoverageSummary>(EMPTY_COVERAGE);
+  const [, setCoverageLoading] = useState(true);
+  const [quota, setQuota] = useState<ShopQuota | null>(null);
+  const [, setQuotaLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [createConfirmOpen, setCreateConfirmOpen] = useState(false);
+  const [targets, setTargets] = useState<string[]>(initialTargets);
+  const [modules, setModules] = useState<string[]>(initialModules);
+  const [aiModel, setAiModel] = useState<string>(initialAiModel);
+  const [isCover, setIsCover] = useState(parseBooleanParam(searchParams.get("isCover")));
+  const [isHandle, setIsHandle] = useState(parseBooleanParam(searchParams.get("isHandle")));
+  const [includeLiquid, setIncludeLiquid] = useState(
+    parseBooleanParam(searchParams.get("includeLiquid")),
+  );
+
+  const normalizedQuota = useMemo(() => normalizeShopQuota(quota), [quota]);
+  const remainingCredits = normalizedQuota?.remaining ?? null;
+  const planType = plan?.type?.trim() || null;
+  const normalizedPlanType = planType?.trim().toLowerCase() || "";
+  const hasPaidPlan =
+    normalizedPlanType !== "" && normalizedPlanType !== "free";
+  const createDisabledMessage =
+    normalizedQuota == null ? t("v4.create.quotaUnavailable") : null;
+  const createShouldGateByCredits = shouldBlockCreateTaskByCredits({
+    remainingCredits,
+  });
+  const createQuotaGatePending = createShouldGateByCredits && isNew == null;
+  const createQuotaGateMode: "trial" | "pricing" | null =
+    createShouldGateByCredits && isNew != null
+      ? isNew
+        ? "trial"
+        : "pricing"
+      : null;
+  const untranslatedRatioByLocale = useMemo(
+    () => buildUntranslatedRatioByLocale(coverage.locales),
+    [coverage.locales],
+  );
+
+  const taskEstimate = useCreateTaskEstimate({
+    modules,
+    targets,
+    isCover,
+    includeLiquid,
+    untranslatedRatioByLocale,
+    remainingCredits,
+  });
+  const createConfirmScenario:
+    | "ready"
+    | "insufficient_paid"
+    | "insufficient_trial"
+    | "insufficient_pricing" =
+    taskEstimate.needsMoreCredits
+      ? hasPaidPlan
+        ? "insufficient_paid"
+        : createQuotaGateMode === "trial"
+          ? "insufficient_trial"
+          : "insufficient_pricing"
+      : "ready";
+  const shouldSkipCreateConfirm = (remainingCredits ?? 0) > 30_000;
+
+  const persistCreateTaskDraft = useCallback(() => {
+    saveCreateTaskDraft(shop, {
+      targets,
+      modules,
+      aiModel,
+      isCover,
+      isHandle,
+    });
+  }, [aiModel, isCover, isHandle, modules, shop, targets]);
+
+  const refreshCoverage = useCallback(async () => {
+    setCoverageLoading(true);
+    try {
+      const res = await fetch(
+        `/api/translate-v4/coverage?shopName=${encodeURIComponent(shop)}&cache=1`,
+      );
+      const data = await readJsonResponse<{ ok?: boolean; summary?: CoverageSummary }>(res);
+      if (data.ok && data.summary) {
+        setCoverage(data.summary);
+      }
+    } catch (err) {
+      console.error("[translate-v4-mvp-custom] refresh coverage failed:", err);
+      message.error(t("v4.actionFailedRetry"));
+    } finally {
+      setCoverageLoading(false);
+    }
+  }, [shop, t]);
+
+  const refreshQuota = useCallback(async () => {
+    setQuotaLoading(true);
+    try {
+      const res = await fetch(
+        `/api/translate-v4/quota?shopName=${encodeURIComponent(shop)}`,
+      );
+      const data = await readJsonResponse<{ ok?: boolean; quota?: ShopQuota | null }>(res);
+      if (data.ok) {
+        setQuota(data.quota ?? null);
+      }
+    } catch (err) {
+      console.error("[translate-v4-mvp-custom] refresh quota failed:", err);
+    } finally {
+      setQuotaLoading(false);
+    }
+  }, [shop]);
+
+  useEffect(() => {
+    void Promise.all([refreshCoverage(), refreshQuota()]);
+  }, [refreshCoverage, refreshQuota]);
+
+  useEffect(() => {
+    if (billingDraftRestoredRef.current) return;
+    const billing = parseBillingReturn(location.search);
+    if (!billing) return;
+    billingDraftRestoredRef.current = true;
+
+    const cleanedPath = stripBillingReturnParams(
+      `${location.pathname}${location.search}${location.hash}`,
+    );
+    navigate(cleanedPath, { replace: true });
+
+    const draft = loadCreateTaskDraft(shop);
+    if (!draft) return;
+
+    const allowedTargets = new Set(targetOptions.map((option) => option.value));
+    const restoredTargets = draft.targets.filter((locale) =>
+      allowedTargets.has(locale),
+    );
+    const allowedModules = new Set<string>(DEFAULT_MODULE_KEYS);
+    const restoredModules = draft.modules.filter((mod) =>
+      allowedModules.has(mod),
+    );
+    const allowedModels = new Set(AI_MODEL_OPTIONS.map((option) => option.value));
+    const restoredModel = allowedModels.has(draft.aiModel)
+      ? draft.aiModel
+      : DEFAULT_AI_MODEL;
+
+    if (restoredTargets.length > 0) setTargets(restoredTargets);
+    if (restoredModules.length > 0) setModules(restoredModules);
+    setAiModel(restoredModel);
+    setIsCover(draft.isCover);
+    setIsHandle(draft.isHandle);
+    setCreateConfirmOpen(true);
+    void refreshQuota();
+    message.info(t("v4.create.draftRestored"));
+  }, [
+    location.hash,
+    location.pathname,
+    location.search,
+    navigate,
+    refreshQuota,
+    shop,
+    t,
+    targetOptions,
+  ]);
+
+  const handleCreateConfirm = useCallback(async () => {
+    if (createQuotaGatePending) {
+      message.info(
+        t("Checking your trial eligibility. Please try again in a moment."),
+      );
+      return;
+    }
+    if (createQuotaGateMode !== null) return;
+    if (remainingCredits == null) {
+      message.info(t("v4.create.quotaUnavailable"));
+      return;
+    }
+
+    setCreateConfirmOpen(false);
+    clearCreateTaskDraft(shop);
+    setCreating(true);
+    try {
+      const result = await createTranslateV4Tasks({
+        source: primaryLocale,
+        targets,
+        modules: expandV2ModuleKeys(modules),
+        aiModel,
+        isCover,
+        isHandle,
+        includeLiquid,
+        targetOptions,
+        shop,
+      });
+
+      if (result.validationError) {
+        message.warning(translateV4Message(result.validationError, t));
+        return;
+      }
+
+      const resultMessage = formatV4CreateTasksMessage(result, t, localeRegionCode);
+      if (result.created.length > 0) {
+        message.success(resultMessage);
+        if (result.failed.length > 0) {
+          message.warning(
+            result.failed
+              .map(
+                (item) =>
+                  `${localeRegionCode(item.target)}: ${translateV4Message(item.error, t)}`,
+              )
+              .join("；"),
+            6,
+          );
+        }
+        navigate("/app/translate-v4-mvp?tab=queue");
+      } else {
+        message.error(resultMessage);
+      }
+    } catch (err) {
+      console.error("[translate-v4-mvp-custom] create tasks failed:", err);
+      message.error(t("v4.createFailedRetry"));
+    } finally {
+      setCreating(false);
+    }
+  }, [
+    aiModel,
+    createQuotaGateMode,
+    createQuotaGatePending,
+    includeLiquid,
+    isCover,
+    isHandle,
+    modules,
+    navigate,
+    primaryLocale,
+    remainingCredits,
+    shop,
+    t,
+    targetOptions,
+    targets,
+  ]);
+
+  const handleCreateRequest = useCallback(() => {
+    if (createQuotaGatePending) {
+      message.info(
+        t("Checking your trial eligibility. Please try again in a moment."),
+      );
+      return;
+    }
+    if (shouldSkipCreateConfirm) {
+      void handleCreateConfirm();
+      return;
+    }
+    setCreateConfirmOpen(true);
+  }, [createQuotaGatePending, handleCreateConfirm, shouldSkipCreateConfirm, t]);
+
+  return (
+    <Page>
+      <TitleBar title={t("v4Mvp.customPage.title")} />
+      <div style={v4ContentStyle}>
+        <BlockStack gap="500">
+          <BlockStack gap="200">
+            <div>
+              <Button
+                variant="plain"
+                size="slim"
+                onClick={() => navigate("/app/translate-v4-mvp")}
+              >
+                {t("v4.back")}
+              </Button>
+            </div>
+            <Text as="h1" variant="headingLg">
+              {t("v4Mvp.customPage.title")}
+            </Text>
+            <Text as="p" tone="subdued" variant="bodyMd">
+              {t("v4Mvp.customPage.subtitle")}
+            </Text>
+          </BlockStack>
+
+          <CreateTaskCard
+            targetOptions={targetOptions}
+            targets={targets}
+            onTargetsChange={setTargets}
+            modules={modules}
+            onModulesChange={setModules}
+            creating={creating}
+            createDisabled={normalizedQuota == null}
+            disabledMessage={createDisabledMessage}
+            onCreate={handleCreateRequest}
+            aiModel={aiModel}
+            onAiModelChange={setAiModel}
+            isCover={isCover}
+            onIsCoverChange={setIsCover}
+            isHandle={isHandle}
+            onIsHandleChange={setIsHandle}
+            includeLiquid={includeLiquid}
+            onIncludeLiquidChange={setIncludeLiquid}
+            estimate={taskEstimate}
+          />
+        </BlockStack>
+      </div>
+      <CreateTaskConfirmModal
+        open={createConfirmOpen}
+        creating={creating}
+        targetOptions={targetOptions}
+        targets={targets}
+        modules={modules}
+        aiModel={aiModel}
+        isCover={isCover}
+        isHandle={isHandle}
+        includeLiquid={includeLiquid}
+        sourceLocale={primaryLocale}
+        estimate={taskEstimate}
+        scenario={createConfirmScenario}
+        quotaOfferMode={hasPaidPlan ? "paid" : isNew === true ? "trial" : "pricing"}
+        onClose={() => setCreateConfirmOpen(false)}
+        onConfirmCreate={handleCreateConfirm}
+        onBeforeBilling={persistCreateTaskDraft}
+        onBuyCredits={(detailedCredits) => {
+          setCreateConfirmOpen(false);
+          openCreditsPurchaseModal(
+            buildCreateTaskCreditsPurchaseContext({
+              estimatedCredits:
+                detailedCredits ?? taskEstimate?.estimatedCredits ?? null,
+              currentRemainingCredits: remainingCredits,
+              targetsCount: targets.length,
+              modulesCount: modules.length,
+            }),
+          );
+        }}
+      />
+    </Page>
+  );
+}

--- a/app/routes/app.translate-v4-mvp/route.tsx
+++ b/app/routes/app.translate-v4-mvp/route.tsx
@@ -1,0 +1,1786 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData, useNavigate, useSearchParams } from "@remix-run/react";
+import { TitleBar } from "@shopify/app-bridge-react";
+import { useSelector } from "react-redux";
+import {
+  Badge,
+  BlockStack,
+  Button,
+  InlineStack,
+  Modal,
+  Page,
+  ProgressBar,
+  Text,
+} from "@shopify/polaris";
+import { useTranslation } from "react-i18next";
+import { message } from "~/ui/message";
+import { authenticate } from "~/shopify.server";
+import type { RootState } from "~/store";
+import { loadShopLocalesForTranslation } from "~/server/translateV4/shopLocales.server";
+import { expandV2ModuleKeys } from "~/server/translateV4/moduleCatalog";
+import type { CoverageSummary } from "~/server/translateV4/coverage.server";
+import type { TranslationJobProgressSummary } from "~/server/translateV4/progress.server";
+import {
+  DEFAULT_AI_MODEL,
+  DEFAULT_MODULE_KEYS,
+} from "~/routes/app.translate-v4/constants";
+import {
+  buildUntranslatedRatioByLocale,
+  type CreateTaskEstimateView,
+  formatEstimateCredits,
+} from "~/routes/app.translate-v4/useCreateTaskEstimate";
+import {
+  formatV4CreateTasksMessage,
+  translateV4Message,
+} from "~/routes/app.translate-v4/v4I18n";
+import { notifyTranslationStatsUpdated } from "~/lib/translationStatsSync";
+import { TaskQueueSection } from "~/routes/app.translate-v4/components/TaskQueueSection";
+import { PageHeaderBar } from "~/routes/app.translate-v4/components/SummaryAndHeader";
+import { CreateTaskConfirmModal } from "~/routes/app.translate-v4/components/CreateTaskConfirmModal";
+import { v4CardStyle, v4Colors, v4ContentStyle } from "~/routes/app.translate-v4/v4Styles";
+import {
+  AppMetricTile,
+  AppPill,
+  AppProgressRing,
+  AppSectionCard,
+  AppStatusBadge,
+} from "~/ui/components";
+import { appColors } from "~/ui/tokens";
+import { localeRegionCode, localeShortName } from "~/routes/app.translate-v4/localeDisplay";
+import { shouldPollV4Job } from "~/routes/app.translate-v4/jobFilters";
+import {
+  createTranslateV4Tasks,
+  type ShopLocaleOption,
+} from "~/lib/createTranslateV4Tasks";
+import { shouldBlockCreateTaskByCredits } from "~/lib/createTranslateQuotaGuard";
+import { normalizeShopQuota, type ShopQuota } from "~/lib/translationQuota";
+import { openCreditsPurchaseModal } from "~/utils/creditsPurchaseModal";
+import {
+  buildCreateTaskCreditsPurchaseContext,
+  buildTranslateV4TaskCreditsPurchaseContext,
+} from "~/utils/creditsPurchaseTaskContext";
+
+const EMPTY_COVERAGE: CoverageSummary = {
+  languageCount: 0,
+  translatedItems: 0,
+  totalItems: 0,
+  overallPercent: null,
+  locales: [],
+};
+
+const QUOTA_POLL_MIN_INTERVAL_MS = 60_000;
+
+const SUMMARY_VIDEO_URL = "https://www.youtube.com/watch?v=AJ0RZkCQMd0&t=9s";
+
+type RecommendationTone = "success" | "attention" | "info";
+
+type Recommendation = {
+  id: string;
+  title: string;
+  locale: string;
+  reasons: string[];
+  targets: string[];
+  modules: string[];
+  pendingItems: number;
+  coveragePercent: number | null;
+  contentChanged: boolean;
+  tone: RecommendationTone;
+};
+
+type InitializingRecommendation = {
+  id: string;
+  title: string;
+  locale: string;
+  targets: string[];
+  modules: string[];
+  tone: RecommendationTone;
+  statusText: string;
+};
+
+type PendingCreateConfig = {
+  recommendationId: string | null;
+  targets: string[];
+  modules: string[];
+  aiModel: string;
+  isCover: boolean;
+  isHandle: boolean;
+  includeLiquid: boolean;
+  estimate: CreateTaskEstimateView | null;
+};
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+
+  let locales: ShopLocaleOption[] = [];
+  let primaryLocale = "en";
+
+  try {
+    const loaded = await loadShopLocalesForTranslation({
+      shop: session.shop,
+      accessToken: session.accessToken as string,
+    });
+    locales = loaded.localeOptions;
+    primaryLocale = loaded.primaryLocale;
+  } catch (err) {
+    console.error("[translate-v4-mvp] load locales failed:", err);
+  }
+
+  return json({
+    shop: session.shop,
+    locales,
+    primaryLocale,
+  });
+};
+
+async function readJsonResponse<T = unknown>(res: Response): Promise<T> {
+  const text = await res.text();
+  if (!text.trim()) {
+    throw new Error(`Empty response body (${res.status})`);
+  }
+  return JSON.parse(text) as T;
+}
+
+function estimateTimeLabel(workload: number, t: ReturnType<typeof useTranslation>["t"]) {
+  if (workload <= 200) return t("v4Mvp.time.fast");
+  if (workload <= 1_000) return t("v4Mvp.time.medium");
+  if (workload <= 4_000) return t("v4Mvp.time.long");
+  return t("v4Mvp.time.xlong");
+}
+
+function formatMvpEstimateCredits(n: number): string {
+  return `${formatEstimateCredits(n)} Credit`;
+}
+
+function extractYoutubeVideoId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.replace(/^www\./, "");
+    let videoId = "";
+
+    if (host === "youtube.com" || host === "m.youtube.com") {
+      videoId = parsed.searchParams.get("v") ?? "";
+    } else if (host === "youtu.be") {
+      videoId = parsed.pathname.replace("/", "");
+    }
+
+    return videoId || null;
+  } catch {
+    return null;
+  }
+}
+
+function buildYoutubeThumbnailUrl(url: string): string | null {
+  const videoId = extractYoutubeVideoId(url);
+  if (!videoId) return null;
+  return `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+}
+
+function buildScanSummary(
+  before: CoverageSummary,
+  after: CoverageSummary,
+  t: ReturnType<typeof useTranslation>["t"],
+): string {
+  const changedLocaleCodes = findChangedLocaleCodes(before, after);
+  const beforePending = Math.max(before.totalItems - before.translatedItems, 0);
+  const afterPending = Math.max(after.totalItems - after.translatedItems, 0);
+  const pendingDelta = afterPending - beforePending;
+  const changedLocales = changedLocaleCodes.length;
+
+  if (pendingDelta > 0) {
+    return t("v4Mvp.scan.summaryPending", {
+      count: pendingDelta,
+      locales: changedLocales,
+    });
+  }
+  if (changedLocales > 0) {
+    return t("v4Mvp.scan.summaryChangedLocales", {
+      count: changedLocales,
+    });
+  }
+  return t("v4Mvp.scan.summaryNoChanges");
+}
+
+function findChangedLocaleCodes(
+  before: CoverageSummary,
+  after: CoverageSummary,
+): string[] {
+  return after.locales
+    .filter((row) => {
+      const previous = before.locales.find((item) => item.locale === row.locale);
+      if (!previous) return true;
+      return (
+        previous.total !== row.total ||
+        previous.translated !== row.translated ||
+        previous.percent !== row.percent
+      );
+    })
+    .map((row) => row.locale);
+}
+
+function coverageTone(percent: number | null): "success" | "attention" | "info" {
+  if (percent == null) return "info";
+  if (percent >= 90) return "success";
+  return "attention";
+}
+
+function coverageStatusBadgeTone(
+  percent: number | null,
+): "info" | "success" | "caution" {
+  if (percent == null) return "info";
+  if (percent >= 90) return "success";
+  return "caution";
+}
+
+function getCoverageRating(
+  percent: number | null,
+  t: ReturnType<typeof useTranslation>["t"],
+) {
+  if (percent == null) {
+    return {
+      label: t("v4.coverage.notScanned"),
+      accent: appColors.textTertiary,
+    };
+  }
+
+  const accent = v4Colors.primary;
+
+  if (percent >= 100) {
+    return {
+      label: t("v4Mvp.coverageCard.ratingAmazing"),
+      accent,
+    };
+  }
+
+  if (percent >= 80) {
+    return {
+      label: t("v4Mvp.coverageCard.ratingExcellent"),
+      accent,
+    };
+  }
+
+  if (percent >= 60) {
+    return {
+      label: t("v4Mvp.coverageCard.ratingQualified"),
+      accent,
+    };
+  }
+
+  return {
+    label: t("v4.coverage.needsImprovement"),
+    accent,
+  };
+}
+
+function buildCustomTranslationPath({
+  targets,
+  modules,
+}: {
+  targets: string[];
+  modules: string[];
+}) {
+  const params = new URLSearchParams();
+  if (targets.length > 0) {
+    params.set("targets", targets.join(","));
+  }
+  if (modules.length > 0) {
+    params.set("modules", modules.join(","));
+  }
+  const query = params.toString();
+  return query
+    ? `/app/translate-v4-mvp-custom?${query}`
+    : "/app/translate-v4-mvp-custom";
+}
+
+function buildRecommendations(
+  coverage: CoverageSummary,
+  jobs: TranslationJobProgressSummary[],
+  changedLocaleCodes: string[],
+  t: ReturnType<typeof useTranslation>["t"],
+): Recommendation[] {
+  const activeTargets = new Set(
+    jobs
+      .filter((job) => !job.isTerminal)
+      .map((job) => job.target.trim().toLowerCase()),
+  );
+  const changedLocaleSet = new Set(changedLocaleCodes.map((item) => item.trim().toLowerCase()));
+
+  return coverage.locales
+    .map((row) => ({
+      ...row,
+      pendingItems: Math.max(row.total - row.translated, 0),
+    }))
+    .filter((row) => !activeTargets.has(row.locale.trim().toLowerCase()))
+    .map((row) => {
+      const coverageInsufficient = row.total > 0 && (row.percent ?? 0) < 100;
+      const contentChanged = changedLocaleSet.has(row.locale.trim().toLowerCase());
+      const reasons: string[] = [];
+
+      if (coverageInsufficient) {
+        reasons.push(
+          t("v4Mvp.recommended.reasonCoverage", {
+            percent: row.percent ?? 0,
+          }),
+        );
+      }
+
+      if (contentChanged) {
+        reasons.push(t("v4Mvp.recommended.reasonChanged"));
+      }
+
+      return {
+        id: `locale-${row.locale}`,
+        title: t("v4Mvp.recommended.localeTaskTitle", {
+          locale: localeShortName(row.locale, row.label),
+        }),
+        locale: row.locale,
+        reasons,
+        targets: [row.locale],
+        modules: DEFAULT_MODULE_KEYS,
+        pendingItems: row.pendingItems,
+        coveragePercent: coverageInsufficient ? (row.percent ?? 0) : null,
+        contentChanged,
+        tone: contentChanged ? "info" : coverageTone(row.percent),
+      } satisfies Recommendation;
+    })
+    .filter((item) => item.reasons.length > 0)
+    .sort((a, b) => {
+      if (a.contentChanged !== b.contentChanged) return a.contentChanged ? -1 : 1;
+      return b.pendingItems - a.pendingItems;
+    });
+}
+
+export default function TranslateV4MvpRoute() {
+  const { t } = useTranslation();
+  const { shop, locales, primaryLocale } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const initialWorkbenchTabParam = searchParams.get("tab");
+  const plan = useSelector((state: RootState) => state.userConfig.plan);
+  const isNew = useSelector((state: RootState) => state.userConfig.isNew);
+  const queueSectionRef = useRef<HTMLDivElement | null>(null);
+  const defaultWorkbenchTabResolvedRef = useRef(false);
+
+  const targetOptions = useMemo(
+    () =>
+      locales.filter((locale) => locale.value !== primaryLocale) as ShopLocaleOption[],
+    [locales, primaryLocale],
+  );
+
+  const [coverage, setCoverage] = useState<CoverageSummary>(EMPTY_COVERAGE);
+  const [coverageLoading, setCoverageLoading] = useState(true);
+  const [jobs, setJobs] = useState<TranslationJobProgressSummary[]>([]);
+  const [jobsLoading, setJobsLoading] = useState(true);
+  const [quota, setQuota] = useState<ShopQuota | null>(null);
+  const [scanSummary, setScanSummary] = useState<string | null>(null);
+  const [changedLocaleCodes, setChangedLocaleCodes] = useState<string[]>([]);
+  const [scanLoading, setScanLoading] = useState(false);
+  const [workbenchTab, setWorkbenchTab] = useState<"recommended" | "queue">(
+    initialWorkbenchTabParam === "queue" ? "queue" : "recommended",
+  );
+  const [coverageDetailOpen, setCoverageDetailOpen] = useState(false);
+  const [createConfirmConfig, setCreateConfirmConfig] = useState<PendingCreateConfig | null>(
+    null,
+  );
+  const [creating, setCreating] = useState(false);
+  const coverageRef = useRef<CoverageSummary>(EMPTY_COVERAGE);
+  const planType = plan?.type?.trim() || null;
+
+  const customTargets = useMemo(
+    () =>
+      targetOptions.map((option) => option.value),
+    [targetOptions],
+  );
+  const customModules = DEFAULT_MODULE_KEYS;
+
+  const untranslatedRatioByLocale = useMemo(
+    () => buildUntranslatedRatioByLocale(coverage.locales),
+    [coverage.locales],
+  );
+  const coverageRating = useMemo(
+    () => getCoverageRating(coverage.overallPercent, t),
+    [coverage.overallPercent, t],
+  );
+  const hasCoverageData = !(coverageLoading && coverage.locales.length === 0);
+  const pendingCoverageItems = Math.max(coverage.totalItems - coverage.translatedItems, 0);
+  const summaryVideoThumbnailUrl = useMemo(
+    () => buildYoutubeThumbnailUrl(SUMMARY_VIDEO_URL),
+    [],
+  );
+  const normalizedQuota = useMemo(() => normalizeShopQuota(quota), [quota]);
+  const remainingCredits = normalizedQuota?.remaining ?? null;
+  const normalizedPlanType = planType?.trim().toLowerCase() || "";
+  const hasPaidPlan =
+    normalizedPlanType !== "" && normalizedPlanType !== "free";
+  const createShouldGateByCredits = shouldBlockCreateTaskByCredits({
+    remainingCredits,
+  });
+  const createQuotaGatePending = createShouldGateByCredits && isNew == null;
+  const createQuotaGateMode: "trial" | "pricing" | null =
+    createShouldGateByCredits && isNew != null
+      ? isNew
+        ? "trial"
+        : "pricing"
+      : null;
+
+  const recommendations = useMemo(
+    () => buildRecommendations(coverage, jobs, changedLocaleCodes, t),
+    [changedLocaleCodes, coverage, jobs, t],
+  );
+  const isCoverageInitializing =
+    targetOptions.length > 0 &&
+    jobs.length === 0 &&
+    coverage.overallPercent == null &&
+    coverage.locales.length === 0 &&
+    !scanSummary;
+  const initializationRecommendations = useMemo(
+    () =>
+      isCoverageInitializing
+        ? targetOptions.map((option) => ({
+            id: `init-${option.value}`,
+            title: t("v4Mvp.recommended.localeTaskTitle", {
+              locale: localeShortName(option.value, option.label),
+            }),
+            locale: option.value,
+            targets: [option.value],
+            modules: DEFAULT_MODULE_KEYS,
+            tone: "info" as const,
+            statusText: t("v4Mvp.recommended.statusComputing", {
+              defaultValue: "Status: calculating...",
+            }),
+          }))
+        : [],
+    [isCoverageInitializing, t, targetOptions],
+  );
+  const [submittingRecommendationIds, setSubmittingRecommendationIds] = useState<string[]>([]);
+  const [recommendationEstimates, setRecommendationEstimates] = useState<
+    Record<string, number | null>
+  >({});
+
+  const refreshQuota = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/translate-v4/quota?shopName=${encodeURIComponent(shop)}`,
+      );
+      const data = await readJsonResponse<{ ok?: boolean; quota?: ShopQuota | null }>(res);
+      if (data.ok) {
+        setQuota(data.quota ?? null);
+      }
+    } catch (err) {
+      console.error("[translate-v4-mvp] refresh quota failed:", err);
+    }
+  }, [shop]);
+
+  const refreshQuotaRef = useRef<() => void>(() => {});
+  refreshQuotaRef.current = refreshQuota;
+
+  const refreshCoverageFromCache = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/translate-v4/coverage?shopName=${encodeURIComponent(shop)}&cache=1`,
+      );
+      const data = await readJsonResponse<{ ok?: boolean; summary?: CoverageSummary }>(res);
+      if (data.ok && data.summary) {
+        setCoverage(data.summary);
+      }
+    } catch (err) {
+      console.warn("[translate-v4-mvp] refresh coverage from cache failed:", err);
+    }
+  }, [shop]);
+
+  const jobStatusRef = useRef<Map<string, string>>(new Map());
+  const jobTerminalRef = useRef<Map<string, boolean>>(new Map());
+  const applyJobsUpdate = useCallback((newJobs: TranslationJobProgressSummary[]) => {
+    for (const job of newJobs) {
+      const previousStatus = jobStatusRef.current.get(job.taskId);
+      if (job.status === "COMPLETED" && previousStatus !== "COMPLETED") {
+        void refreshCoverageFromCache();
+        notifyTranslationStatsUpdated({ target: job.target, source: job.source });
+      }
+
+      const wasTerminal = jobTerminalRef.current.get(job.taskId);
+      if (job.isTerminal && wasTerminal === false) {
+        refreshQuotaRef.current();
+      }
+
+      jobStatusRef.current.set(job.taskId, job.status);
+      jobTerminalRef.current.set(job.taskId, Boolean(job.isTerminal));
+    }
+    setJobs(newJobs);
+  }, [refreshCoverageFromCache]);
+
+  const refreshTasks = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/translate-v4/tasks?shopName=${encodeURIComponent(shop)}`,
+      );
+      const data = await readJsonResponse<{ ok?: boolean; jobs?: TranslationJobProgressSummary[] }>(
+        res,
+      );
+      if (data.ok && Array.isArray(data.jobs)) {
+        applyJobsUpdate(data.jobs);
+      }
+    } catch (err) {
+      console.error("[translate-v4-mvp] refresh tasks failed:", err);
+    } finally {
+      setJobsLoading(false);
+    }
+  }, [applyJobsUpdate, shop]);
+
+  const refreshCoverage = useCallback(
+    async (forceRefresh = false) => {
+      if (forceRefresh) setScanLoading(true);
+      else setCoverageLoading(true);
+
+      const before = coverageRef.current;
+
+      try {
+        if (!forceRefresh) {
+          const res = await fetch(
+            `/api/translate-v4/coverage?shopName=${encodeURIComponent(shop)}&cache=1`,
+          );
+          const data = await readJsonResponse<{ ok?: boolean; summary?: CoverageSummary }>(res);
+          if (data.ok && data.summary) {
+            setCoverage(data.summary);
+          }
+          return;
+        }
+
+        let latestSummary: CoverageSummary | null = null;
+        for (const locale of targetOptions) {
+          const res = await fetch(
+            `/api/translate-v4/coverage?shopName=${encodeURIComponent(shop)}&refresh=1&locales=${encodeURIComponent(locale.value)}`,
+          );
+          const data = await readJsonResponse<{ ok?: boolean; summary?: CoverageSummary }>(res);
+          if (data.ok && data.summary) {
+            latestSummary = data.summary;
+            setCoverage(data.summary);
+          }
+        }
+
+        if (latestSummary) {
+          setChangedLocaleCodes(findChangedLocaleCodes(before, latestSummary));
+          setScanSummary(buildScanSummary(before, latestSummary, t));
+        } else {
+          setScanSummary(t("v4Mvp.scan.summaryUpdated"));
+          setChangedLocaleCodes([]);
+        }
+      } catch (err) {
+        console.error("[translate-v4-mvp] refresh coverage failed:", err);
+        message.error(t("v4.actionFailedRetry"));
+      } finally {
+        setCoverageLoading(false);
+        setScanLoading(false);
+      }
+    },
+    [shop, t, targetOptions],
+  );
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([refreshTasks(), refreshQuota(), refreshCoverage(false)]);
+  }, [refreshCoverage, refreshQuota, refreshTasks]);
+
+  useEffect(() => {
+    void refreshAll();
+  }, [refreshAll]);
+
+  useEffect(() => {
+    coverageRef.current = coverage;
+  }, [coverage]);
+
+  useEffect(() => {
+    if (!recommendations.length) {
+      setRecommendationEstimates({});
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      const next: Record<string, number | null> = {};
+      for (const item of recommendations) {
+        try {
+          const res = await fetch("/api/translate-v4/estimate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              modules: item.modules,
+              targets: item.targets,
+              isCover: false,
+              includeLiquid: false,
+              untranslatedRatioByLocale,
+            }),
+          });
+          const data = await readJsonResponse<{
+            ok?: boolean;
+            estimate?: { estimatedCredits?: number | null };
+          }>(res);
+          next[item.id] = data.ok ? (data.estimate?.estimatedCredits ?? null) : null;
+        } catch {
+          next[item.id] = null;
+        }
+      }
+      if (!cancelled) {
+        setRecommendationEstimates(next);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [recommendations, untranslatedRatioByLocale]);
+
+  const currentJobs = useMemo(() => jobs.filter((job) => !job.isTerminal), [jobs]);
+  const activeTaskCount = currentJobs.length;
+  const translateSlotBusy = useMemo(
+    () => jobs.some((job) => job.status === "TRANSLATING" || job.isStopping),
+    [jobs],
+  );
+  const visibleRecommendations = useMemo(
+    () => recommendations.filter((item) => !submittingRecommendationIds.includes(item.id)),
+    [recommendations, submittingRecommendationIds],
+  );
+  const displayedRecommendations: Array<Recommendation | InitializingRecommendation> =
+    isCoverageInitializing && visibleRecommendations.length === 0
+      ? initializationRecommendations
+      : visibleRecommendations;
+  const createConfirmScenario:
+    | "ready"
+    | "insufficient_paid"
+    | "insufficient_trial"
+    | "insufficient_pricing" =
+    createConfirmConfig?.estimate?.needsMoreCredits
+      ? hasPaidPlan
+        ? "insufficient_paid"
+        : createQuotaGateMode === "trial"
+          ? "insufficient_trial"
+          : "insufficient_pricing"
+      : "ready";
+
+  const createTasksWithConfig = useCallback(async ({
+    nextTargets,
+    nextModules,
+    nextAiModel = DEFAULT_AI_MODEL,
+    nextIsCover = false,
+    nextIsHandle = false,
+    nextIncludeLiquid = false,
+  }: {
+    nextTargets: string[];
+    nextModules: string[];
+    nextAiModel?: string;
+    nextIsCover?: boolean;
+    nextIsHandle?: boolean;
+    nextIncludeLiquid?: boolean;
+  }) => {
+    try {
+      const result = await createTranslateV4Tasks({
+        source: primaryLocale,
+        targets: nextTargets,
+        modules: expandV2ModuleKeys(nextModules),
+        aiModel: nextAiModel,
+        isCover: nextIsCover,
+        isHandle: nextIsHandle,
+        includeLiquid: nextIncludeLiquid,
+        targetOptions,
+        shop,
+      });
+
+      if (result.validationError) {
+        message.warning(translateV4Message(result.validationError, t));
+        return false;
+      }
+
+      const summary = formatV4CreateTasksMessage(result, t, localeRegionCode);
+      if (result.created.length > 0) {
+        message.success(`${summary} ${t("v4.create.createdBelow")}`);
+        await Promise.all([refreshTasks(), refreshQuota(), refreshCoverage(false)]);
+        setWorkbenchTab("queue");
+        setTimeout(() => {
+          queueSectionRef.current?.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+          });
+        }, 120);
+        if (result.failed.length > 0) {
+          message.warning(
+            result.failed
+              .map(
+                (item) =>
+                  `${localeRegionCode(item.target)}: ${translateV4Message(item.error, t)}`,
+              )
+              .join("；"),
+            6,
+          );
+        }
+        return true;
+      } else {
+        message.error(summary);
+        return false;
+      }
+    } catch (err) {
+      console.error("[translate-v4-mvp] create tasks failed:", err);
+      message.error(t("v4.createFailedRetry"));
+      return false;
+    }
+  }, [
+    primaryLocale,
+    refreshCoverage,
+    refreshQuota,
+    refreshTasks,
+    shop,
+    t,
+    targetOptions,
+  ]);
+
+  const openTaskCreditsModal = useCallback(
+    (job: TranslationJobProgressSummary) => {
+      openCreditsPurchaseModal(
+        buildTranslateV4TaskCreditsPurchaseContext(
+          job,
+          normalizedQuota?.remaining ?? null,
+        ),
+      );
+    },
+    [normalizedQuota],
+  );
+
+  const jobsRef = useRef<TranslationJobProgressSummary[]>([]);
+
+  useEffect(() => {
+    jobsRef.current = jobs;
+  }, [jobs]);
+
+  useEffect(() => {
+    let disposed = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let stablePollCount = 0;
+    let lastActiveJobsSignature = "";
+    let lastQuotaAt = Date.now();
+
+    const getNextDelay = () => {
+      if (typeof document !== "undefined" && document.hidden) return 30_000;
+      return Math.min(30_000, 3_000 * 2 ** Math.min(stablePollCount, 3));
+    };
+
+    const poll = () => {
+      if (disposed) return;
+      const hasActive = jobsRef.current.some(shouldPollV4Job);
+      if (!hasActive) {
+        stablePollCount = 0;
+        timer = setTimeout(poll, 10_000);
+        return;
+      }
+
+      const signature = jobsRef.current
+        .filter(shouldPollV4Job)
+        .map((job) => `${job.taskId}:${job.status}:${job.progressPercent ?? ""}:${job.updatedAt}`)
+        .join("|");
+
+      stablePollCount =
+        signature === lastActiveJobsSignature ? stablePollCount + 1 : 0;
+      lastActiveJobsSignature = signature;
+
+      if (typeof document === "undefined" || !document.hidden) {
+        void refreshTasks();
+        if (Date.now() - lastQuotaAt >= QUOTA_POLL_MIN_INTERVAL_MS) {
+          lastQuotaAt = Date.now();
+          void refreshQuota();
+        }
+      }
+
+      timer = setTimeout(poll, getNextDelay());
+    };
+
+    timer = setTimeout(poll, 3_000);
+
+    return () => {
+      disposed = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [refreshQuota, refreshTasks]);
+
+  useEffect(() => {
+    if (defaultWorkbenchTabResolvedRef.current) return;
+    if (initialWorkbenchTabParam === "queue" || initialWorkbenchTabParam === "recommended") {
+      defaultWorkbenchTabResolvedRef.current = true;
+      return;
+    }
+    if (jobsLoading || coverageLoading) return;
+
+    defaultWorkbenchTabResolvedRef.current = true;
+    if (visibleRecommendations.length === 0 && activeTaskCount > 0) {
+      setWorkbenchTab("queue");
+    }
+  }, [
+    activeTaskCount,
+    coverageLoading,
+    initialWorkbenchTabParam,
+    jobsLoading,
+    visibleRecommendations.length,
+  ]);
+
+  const handleRecommendationTranslate = useCallback(async (item: Recommendation) => {
+    if (createQuotaGatePending) {
+      message.info(
+        t("Checking your trial eligibility. Please try again in a moment."),
+      );
+      return;
+    }
+
+    if (remainingCredits == null) {
+      message.info(t("v4.create.quotaUnavailable"));
+      return;
+    }
+
+    if (remainingCredits > 30_000) {
+      setSubmittingRecommendationIds((current) =>
+        current.includes(item.id)
+          ? current
+          : [...current, item.id],
+      );
+      setCreating(true);
+      try {
+        await createTasksWithConfig({
+          nextTargets: item.targets,
+          nextModules: item.modules,
+          nextAiModel: DEFAULT_AI_MODEL,
+          nextIsCover: false,
+          nextIsHandle: false,
+          nextIncludeLiquid: false,
+        });
+      } finally {
+        setCreating(false);
+        setSubmittingRecommendationIds((current) =>
+          current.filter((id) => id !== item.id),
+        );
+      }
+      return;
+    }
+
+    const estimatedCredits = recommendationEstimates[item.id] ?? null;
+    setCreateConfirmConfig({
+      recommendationId: item.id,
+      targets: item.targets,
+      modules: item.modules,
+      aiModel: DEFAULT_AI_MODEL,
+      isCover: false,
+      isHandle: false,
+      includeLiquid: false,
+      estimate: {
+        estimatedCredits,
+        remainingCredits: remainingCredits ?? 0,
+        isUpperBound: true,
+        needsMoreCredits:
+          estimatedCredits != null &&
+          remainingCredits != null &&
+          estimatedCredits > remainingCredits,
+        loading: false,
+        loaded: true,
+      },
+    });
+  }, [
+    createTasksWithConfig,
+    createQuotaGatePending,
+    recommendationEstimates,
+    remainingCredits,
+    t,
+  ]);
+
+  const handleCreateConfirm = useCallback(async () => {
+    if (!createConfirmConfig) return;
+    if (createQuotaGatePending) {
+      message.info(
+        t("Checking your trial eligibility. Please try again in a moment."),
+      );
+      return;
+    }
+    if (createQuotaGateMode !== null) return;
+    if (remainingCredits == null) {
+      message.info(t("v4.create.quotaUnavailable"));
+      return;
+    }
+
+    const recommendationId = createConfirmConfig.recommendationId;
+    setCreateConfirmConfig(null);
+    if (recommendationId) {
+      setSubmittingRecommendationIds((current) =>
+        current.includes(recommendationId)
+          ? current
+          : [...current, recommendationId],
+      );
+    }
+
+    setCreating(true);
+    try {
+      await createTasksWithConfig({
+        nextTargets: createConfirmConfig.targets,
+        nextModules: createConfirmConfig.modules,
+        nextAiModel: createConfirmConfig.aiModel,
+        nextIsCover: createConfirmConfig.isCover,
+        nextIsHandle: createConfirmConfig.isHandle,
+        nextIncludeLiquid: createConfirmConfig.includeLiquid,
+      });
+    } finally {
+      setCreating(false);
+      if (recommendationId) {
+        setSubmittingRecommendationIds((current) =>
+          current.filter((id) => id !== recommendationId),
+        );
+      }
+    }
+  }, [
+    createConfirmConfig,
+    createQuotaGateMode,
+    createQuotaGatePending,
+    createTasksWithConfig,
+    remainingCredits,
+    t,
+  ]);
+
+  const handleTaskAction = useCallback(
+    async (
+      taskId: string,
+      actionType: "pause" | "resume" | "cancel" | "delete",
+    ) => {
+      try {
+        const res = await fetch("/api/translate-v4/task-action", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ taskId, shopName: shop, action: actionType }),
+        });
+        const data = await readJsonResponse<{ ok?: boolean; error?: string }>(res);
+        if (data.ok) {
+          const label =
+            actionType === "delete"
+              ? t("v4.deleted")
+              : actionType === "resume"
+                ? t("v4.resuming")
+                : actionType === "pause"
+                  ? t("v4.paused")
+                  : t("v4.cancelled");
+          message.success(label);
+          await Promise.all([refreshTasks(), refreshQuota()]);
+          return true;
+        }
+        if (
+          actionType === "resume" &&
+          data.error === "v4.create.noCreditsPricing"
+        ) {
+          const targetJob = jobs.find((item) => item.taskId === taskId) ?? null;
+          if (targetJob) {
+            openTaskCreditsModal(targetJob);
+          } else {
+            openCreditsPurchaseModal();
+          }
+          return false;
+        }
+        message.error(
+          data.error ? translateV4Message(data.error, t) : t("v4.actionFailed"),
+        );
+        return false;
+      } catch (err) {
+        console.error("[translate-v4-mvp] task action failed:", err);
+        message.error(t("v4.actionFailedRetry"));
+        return false;
+      }
+    },
+    [jobs, openTaskCreditsModal, refreshQuota, refreshTasks, shop, t],
+  );
+
+  return (
+    <Page>
+      <TitleBar title={t("v4.title")} />
+      <div style={v4ContentStyle}>
+        <BlockStack gap="500">
+          <PageHeaderBar
+            credits={normalizedQuota?.remaining ?? null}
+            planType={planType}
+          />
+
+          <div style={summaryHeroGridStyle}>
+            <div style={summaryHeroCardStyle}>
+              <div style={summaryHeroLayoutStyle}>
+                <div style={summaryProgressWrapStyle}>
+                  <AppProgressRing
+                    percent={isCoverageInitializing ? null : hasCoverageData ? coverage.overallPercent : null}
+                    tone="primary"
+                    size={100}
+                    loading={isCoverageInitializing || !hasCoverageData}
+                  />
+                </div>
+
+                <div style={summaryContentStyle}>
+                  <BlockStack gap="100">
+                    <Text as="p" tone="subdued" variant="bodyMd">
+                      {t("v4Mvp.coverageCard.title")}
+                    </Text>
+                    <Text as="p" variant="headingMd">
+                      {isCoverageInitializing
+                        ? t("v4Mvp.coverageCard.summaryComputing", {
+                            defaultValue: "Store translation status is being calculated...",
+                          })
+                        : t("v4Mvp.coverageCard.summary", {
+                            percent: hasCoverageData ? `${coverage.overallPercent ?? 0}%` : "—",
+                          })}
+                    </Text>
+                    <InlineStack gap="150" blockAlign="center" wrap={false}>
+                      <Text
+                        as="p"
+                        variant="headingMd"
+                        style={summaryProgressLabelStyle(coverageRating.accent)}
+                      >
+                        {isCoverageInitializing
+                          ? t("v4Mvp.coverageCard.statusComputing", {
+                              defaultValue: "Calculating...",
+                            })
+                          : coverageRating.label}
+                      </Text>
+                      {coverage.languageCount > 0 ? (
+                        <Text as="span" tone="subdued" variant="bodySm">
+                          {`· ${t("v4Mvp.coverageCard.languageCount", {
+                            total: coverage.languageCount,
+                          })}`}
+                        </Text>
+                      ) : null}
+                    </InlineStack>
+                    {isCoverageInitializing ? (
+                      <Text as="p" tone="subdued" variant="bodySm">
+                        {t("v4Mvp.coverageCard.descriptionComputing", {
+                          defaultValue:
+                            "We are scanning your store content and will show overall coverage once the first calculation finishes.",
+                        })}
+                      </Text>
+                    ) : hasCoverageData && coverage.totalItems > 0 ? (
+                      <Text as="p" tone="subdued" variant="bodySm">
+                        {t("v4Mvp.overview.progress", {
+                          translated: coverage.translatedItems.toLocaleString(),
+                          total: coverage.totalItems.toLocaleString(),
+                        })}
+                      </Text>
+                    ) : null}
+                  </BlockStack>
+                  <div style={summaryButtonWrapStyle}>
+                    <Button
+                      variant="secondary"
+                      disabled={isCoverageInitializing}
+                      onClick={() => setCoverageDetailOpen(true)}
+                    >
+                      {t("v4Mvp.coverageCard.viewDetails")}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <a
+              href={SUMMARY_VIDEO_URL}
+              target="_blank"
+              rel="noreferrer"
+              style={videoPreviewLayerStyle}
+            >
+              <div style={videoPreviewSurfaceStyle}>
+                {summaryVideoThumbnailUrl ? (
+                  <img
+                    alt={t("v4Mvp.videoCard.title")}
+                    src={summaryVideoThumbnailUrl}
+                    style={videoPreviewImageStyle}
+                  />
+                ) : (
+                  <div style={videoPreviewFallbackStyle}>
+                    <Badge tone="attention">{t("v4Mvp.videoCard.unavailable")}</Badge>
+                  </div>
+                )}
+
+                <div style={videoPreviewOverlayStyle}>
+                  <div style={videoPreviewPlayButtonStyle}>
+                    <div style={videoPreviewPlayIconStyle} />
+                  </div>
+                </div>
+
+                <div style={videoPreviewCaptionStyle}>
+                  <Text as="p" variant="bodyMd" style={videoPreviewCaptionTextStyle}>
+                    {t("v4Mvp.videoCard.tutorialTitle")}
+                  </Text>
+                </div>
+              </div>
+            </a>
+          </div>
+
+          <AppSectionCard
+            title={t("v4Mvp.custom.title")}
+            description={t("v4Mvp.custom.description")}
+            extra={
+              <Button
+                variant="primary"
+                onClick={() => navigate(buildCustomTranslationPath({
+                  targets: customTargets,
+                  modules: customModules,
+                }))}
+              >
+                {t("v4Mvp.custom.translate")}
+              </Button>
+            }
+            bodyPadding="20px 24px"
+            style={{ boxShadow: "var(--app-shadow-card)" }}
+          />
+
+          <div ref={queueSectionRef}>
+            <AppSectionCard
+              bodyPadding="20px 24px"
+              style={{ boxShadow: "var(--app-shadow-card-strong)" }}
+            >
+              <BlockStack gap="400">
+                <div style={workbenchHeaderStyle}>
+                  <InlineStack align="space-between" blockAlign="center">
+                    <div style={tabListStyle}>
+                      <button
+                        type="button"
+                        onClick={() => setWorkbenchTab("recommended")}
+                        style={tabButtonStyle(workbenchTab === "recommended")}
+                      >
+                        {t("v4Mvp.tabs.recommended", { count: displayedRecommendations.length })}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setWorkbenchTab("queue")}
+                        style={tabButtonStyle(workbenchTab === "queue")}
+                      >
+                        {t("v4Mvp.tabs.queue", { count: activeTaskCount })}
+                      </button>
+                    </div>
+
+                    {workbenchTab === "recommended" ? (
+                      <InlineStack gap="200">
+                        <Button
+                          variant="secondary"
+                          onClick={() => void refreshCoverage(true)}
+                          loading={scanLoading}
+                        >
+                          {t("v4Mvp.scan.rescan")}
+                        </Button>
+                      </InlineStack>
+                    ) : null}
+                  </InlineStack>
+                </div>
+
+                {workbenchTab === "recommended" ? (
+                  <BlockStack gap="200">
+                    {scanSummary ? (
+                      <div style={scanSummaryStyle}>
+                        <Text as="p" tone="subdued" variant="bodySm">
+                          {scanSummary}
+                        </Text>
+                      </div>
+                    ) : null}
+                    {displayedRecommendations.length > 0 ? (
+                      displayedRecommendations.map((item) => (
+                          <RecommendationCard
+                            key={item.id}
+                            title={item.title}
+                            tone={item.tone}
+                            coveragePercent={"coveragePercent" in item ? item.coveragePercent : null}
+                            contentChanged={"contentChanged" in item ? item.contentChanged : false}
+                            pendingItems={"pendingItems" in item ? item.pendingItems : null}
+                            estimatedCredits={"pendingItems" in item ? (recommendationEstimates[item.id] ?? null) : null}
+                            estimatedTime={"pendingItems" in item ? estimateTimeLabel(item.pendingItems, t) : null}
+                            loading={submittingRecommendationIds.includes(item.id)}
+                            statusText={"statusText" in item ? item.statusText : null}
+                            onTranslate={() => {
+                              if ("pendingItems" in item) {
+                                void handleRecommendationTranslate(item);
+                                return;
+                              }
+
+                              void handleRecommendationTranslate({
+                                id: item.id,
+                                title: item.title,
+                                locale: item.locale,
+                                reasons: [],
+                                targets: item.targets,
+                                modules: item.modules,
+                                pendingItems: 0,
+                                coveragePercent: null,
+                                contentChanged: false,
+                                tone: item.tone,
+                              });
+                            }}
+                          />
+                      ))
+                    ) : (
+                      <div style={emptyStateStyle}>
+                        <div style={emptyStateInnerStyle}>
+                          <BlockStack gap="300">
+                            <BlockStack gap="100">
+                              <Text as="h3" variant="headingMd" alignment="center">
+                                {t("v4Mvp.recommended.emptyTitle")}
+                              </Text>
+                              <Text as="p" tone="subdued" alignment="center">
+                                {t("v4Mvp.recommended.emptyDescription")}
+                              </Text>
+                            </BlockStack>
+                            <InlineStack align="center">
+                              <Button
+                                variant="primary"
+                                size="large"
+                                onClick={() =>
+                                  navigate(
+                                    buildCustomTranslationPath({
+                                      targets: customTargets,
+                                      modules: customModules,
+                                    }),
+                                  )
+                                }
+                              >
+                                {t("v4Mvp.custom.translate")}
+                              </Button>
+                            </InlineStack>
+                            <InlineStack align="center">
+                              <Button
+                                variant="secondary"
+                                size="large"
+                                onClick={() => void refreshCoverage(true)}
+                                loading={scanLoading}
+                              >
+                                {t("v4Mvp.scan.scanStore")}
+                              </Button>
+                            </InlineStack>
+                          </BlockStack>
+                        </div>
+                      </div>
+                    )}
+                  </BlockStack>
+                ) : (
+                  <TaskQueueSection
+                    jobs={jobs}
+                    translateSlotBusy={translateSlotBusy}
+                    loading={jobsLoading}
+                    historyReturnTo="/app/translate-v4-mvp?tab=queue"
+                    emptyStateActionLabel={t("v4Mvp.custom.translate")}
+                    onEmptyStateAction={() =>
+                      navigate(
+                        buildCustomTranslationPath({
+                          targets: customTargets,
+                          modules: customModules,
+                        }),
+                      )
+                    }
+                    onBuyCredits={openTaskCreditsModal}
+                    onAction={handleTaskAction}
+                  />
+                )}
+              </BlockStack>
+            </AppSectionCard>
+          </div>
+        </BlockStack>
+      </div>
+      <Modal
+        open={coverageDetailOpen}
+        onClose={() => setCoverageDetailOpen(false)}
+        title={t("v4Mvp.coverageModal.title")}
+        size="large"
+      >
+        <Modal.Section>
+          <div style={coverageModalShellStyle}>
+            <BlockStack gap="350">
+              <div style={coverageModalHeroStyle}>
+                <BlockStack gap="300">
+                  <Text as="p" tone="subdued" variant="bodyMd">
+                    {t("v4Mvp.coverageModal.description")}
+                  </Text>
+                  <div style={coverageMetricGridStyle}>
+                    <AppMetricTile
+                      label={t("v4.translationProgress")}
+                      value={
+                        hasCoverageData
+                          ? `${coverage.overallPercent ?? 0}%`
+                          : "—"
+                      }
+                      caption={coverageRating.label}
+                    />
+                    <AppMetricTile
+                      label={t("v4Mvp.coverageCard.languageCount", {
+                        total: coverage.languageCount,
+                      })}
+                      value={hasCoverageData ? coverage.languageCount.toLocaleString() : "—"}
+                      caption={t("v4Mvp.coverageCard.title")}
+                    />
+                    <AppMetricTile
+                      label={t("v4.pendingItems")}
+                      value={hasCoverageData ? pendingCoverageItems.toLocaleString() : "—"}
+                      caption={
+                        hasCoverageData && coverage.totalItems > 0
+                          ? t("v4Mvp.overview.progress", {
+                              translated: coverage.translatedItems.toLocaleString(),
+                              total: coverage.totalItems.toLocaleString(),
+                            })
+                          : t("v4Mvp.coverageModal.empty")
+                      }
+                    />
+                  </div>
+                </BlockStack>
+              </div>
+
+              <BlockStack gap="200">
+                {coverage.locales.length > 0 ? (
+                  [...coverage.locales]
+                    .sort((a, b) => (a.percent ?? 0) - (b.percent ?? 0))
+                    .map((locale) => (
+                      <div key={locale.locale} style={coverageRowStyle}>
+                        <InlineStack align="space-between" blockAlign="start" wrap={false}>
+                          <BlockStack gap="050">
+                            <InlineStack gap="150" blockAlign="center" wrap>
+                              <Text as="p" variant="bodyMd">
+                                {localeShortName(locale.locale, locale.label)}
+                              </Text>
+                              <AppPill tone="neutral">
+                                {localeRegionCode(locale.locale)}
+                              </AppPill>
+                              <AppStatusBadge
+                                tone={coverageStatusBadgeTone(locale.percent)}
+                              >
+                                {getCoverageRating(locale.percent, t).label}
+                              </AppStatusBadge>
+                            </InlineStack>
+                            <Text as="p" tone="subdued" variant="bodySm">
+                              {t("v4Mvp.coverageModal.progressText", {
+                                translated: locale.translated,
+                                total: locale.total,
+                              })}
+                            </Text>
+                          </BlockStack>
+                          <div style={coveragePercentWrapStyle}>
+                            <Text as="p" variant="headingMd">
+                              {`${locale.percent ?? 0}%`}
+                            </Text>
+                          </div>
+                        </InlineStack>
+                        <ProgressBar progress={locale.percent ?? 0} size="small" tone="primary" />
+                      </div>
+                    ))
+                ) : (
+                  <div style={coverageModalEmptyStyle}>
+                    <Text as="p" tone="subdued">
+                      {t("v4Mvp.coverageModal.empty")}
+                    </Text>
+                  </div>
+                )}
+              </BlockStack>
+            </BlockStack>
+          </div>
+        </Modal.Section>
+      </Modal>
+      <CreateTaskConfirmModal
+        open={createConfirmConfig !== null}
+        creating={creating}
+        targetOptions={targetOptions}
+        targets={createConfirmConfig?.targets ?? []}
+        modules={createConfirmConfig?.modules ?? []}
+        aiModel={createConfirmConfig?.aiModel ?? DEFAULT_AI_MODEL}
+        isCover={createConfirmConfig?.isCover ?? false}
+        isHandle={createConfirmConfig?.isHandle ?? false}
+        includeLiquid={createConfirmConfig?.includeLiquid ?? false}
+        sourceLocale={primaryLocale}
+        estimate={createConfirmConfig?.estimate ?? null}
+        scenario={createConfirmScenario}
+        quotaOfferMode={hasPaidPlan ? "paid" : isNew === true ? "trial" : "pricing"}
+        onClose={() => {
+          if (!creating) {
+            setCreateConfirmConfig(null);
+          }
+        }}
+        onConfirmCreate={handleCreateConfirm}
+        onBuyCredits={(detailedCredits) => {
+          if (!createConfirmConfig) return;
+          setCreateConfirmConfig(null);
+          openCreditsPurchaseModal(
+            buildCreateTaskCreditsPurchaseContext({
+              estimatedCredits:
+                detailedCredits ?? createConfirmConfig.estimate?.estimatedCredits ?? null,
+              currentRemainingCredits: remainingCredits,
+              targetsCount: createConfirmConfig.targets.length,
+              modulesCount: createConfirmConfig.modules.length,
+            }),
+          );
+        }}
+      />
+    </Page>
+  );
+}
+
+function RecommendationCard({
+  title,
+  tone,
+  coveragePercent,
+  contentChanged,
+  pendingItems,
+  estimatedCredits,
+  estimatedTime,
+  loading = false,
+  statusText = null,
+  onTranslate,
+}: {
+  title: string;
+  tone: RecommendationTone;
+  coveragePercent: number | null;
+  contentChanged: boolean;
+  pendingItems: number | null;
+  estimatedCredits: number | null;
+  estimatedTime: string | null;
+  loading?: boolean;
+  statusText?: string | null;
+  onTranslate: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div style={recommendationRowStyle}>
+      <div style={recommendationMainStyle}>
+        <InlineStack gap="150" blockAlign="center" wrap={false}>
+          <span style={recommendationToneDotStyle(tone)} />
+          <Text as="h3" variant="headingSm" truncate>
+            {title}
+          </Text>
+          {contentChanged ? (
+            <AppStatusBadge tone="info">{t("v4Mvp.recommended.reasonChanged")}</AppStatusBadge>
+          ) : null}
+        </InlineStack>
+        <div style={recommendationMetaListStyle}>
+          {coveragePercent != null ? (
+            <AppPill
+              style={{
+                background: v4Colors.infoBg,
+                color: v4Colors.info,
+                border: "1px solid transparent",
+              }}
+            >
+              {t("v4Mvp.recommended.metaCoverage", { percent: coveragePercent })}
+            </AppPill>
+          ) : null}
+          {pendingItems != null ? (
+            <AppPill tone="warning">
+              {t("v4Mvp.recommended.metaPending", {
+                items: pendingItems.toLocaleString(),
+              })}
+            </AppPill>
+          ) : null}
+          {estimatedCredits != null ? (
+            <AppPill tone="info">
+              {t("v4Mvp.recommended.metaCredits", {
+                credits: formatMvpEstimateCredits(estimatedCredits),
+              })}
+            </AppPill>
+          ) : null}
+          {estimatedTime ? <AppPill tone="success">{estimatedTime}</AppPill> : null}
+        </div>
+        {statusText ? (
+          <Text as="p" tone="subdued" variant="bodySm" style={recommendationStatusTextStyle}>
+            {statusText}
+          </Text>
+        ) : null}
+      </div>
+      <div style={recommendationActionWrapStyle}>
+        <Button
+          size="slim"
+          variant="secondary"
+          loading={loading}
+          onClick={onTranslate}
+        >
+          {t("v4Mvp.recommended.translate")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const tabListStyle = {
+  display: "inline-flex",
+  flexWrap: "wrap",
+  gap: 8,
+  padding: 4,
+  borderRadius: 999,
+  background: appColors.surfaceSecondary,
+} satisfies CSSProperties;
+
+const emptyStateStyle = {
+  minHeight: "240px",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "24px 16px",
+} satisfies CSSProperties;
+
+const coverageRowStyle = {
+  padding: "14px 16px",
+  border: `1px solid ${v4Colors.cardBorder}`,
+  borderRadius: "14px",
+  background: appColors.surface,
+  boxShadow: "var(--app-shadow-card)",
+} satisfies CSSProperties;
+
+const coverageModalShellStyle = {
+  padding: "4px 2px 2px",
+} satisfies CSSProperties;
+
+const coverageModalHeroStyle = {
+  ...v4CardStyle,
+  padding: "16px 18px",
+  background: v4Colors.summaryBg,
+  boxShadow: "var(--app-shadow-card)",
+} satisfies CSSProperties;
+
+const coverageMetricGridStyle = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+  gap: "12px",
+} satisfies CSSProperties;
+
+const coverageModalEmptyStyle = {
+  padding: "28px 18px",
+  borderRadius: "14px",
+  background: appColors.surfaceSecondary,
+  border: `1px dashed ${v4Colors.cardBorder}`,
+} satisfies CSSProperties;
+
+const coveragePercentWrapStyle = {
+  flexShrink: 0,
+  minWidth: "68px",
+  textAlign: "right",
+} satisfies CSSProperties;
+
+const summaryHeroGridStyle = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "18px",
+  alignItems: "stretch",
+  width: "100%",
+} satisfies CSSProperties;
+
+const summaryHeroCardStyle = {
+  ...v4CardStyle,
+  padding: "20px 24px",
+  background: v4Colors.summaryBg,
+  boxShadow: "var(--app-shadow-card-strong)",
+  display: "flex",
+  alignItems: "center",
+  flex: "0.95 1 450px",
+  minWidth: "320px",
+} satisfies CSSProperties;
+
+const videoPreviewLayerStyle = {
+  ...v4CardStyle,
+  padding: "0",
+  overflow: "hidden",
+  color: "inherit",
+  textDecoration: "none",
+  background: "#0f172a",
+  boxShadow: "var(--app-shadow-card-strong)",
+  flex: "1.35 1 10px",
+  minWidth: "150px",
+  minHeight: "100%",
+  display: "block",
+  width: "322px",
+} satisfies CSSProperties;
+
+const summaryHeroLayoutStyle = {
+  display: "flex",
+  alignItems: "center",
+  flexWrap: "wrap",
+  gap: "20px",
+  width: "100%",
+} satisfies CSSProperties;
+
+const summaryContentStyle = {
+  minWidth: 0,
+  flex: "1 1 180px",
+  display: "grid",
+  gap: "4px",
+} satisfies CSSProperties;
+
+const summaryProgressWrapStyle = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+} satisfies CSSProperties;
+
+const summaryButtonWrapStyle = {
+  display: "flex",
+  alignItems: "center",
+  flexShrink: 0,
+  marginLeft: "auto",
+} satisfies CSSProperties;
+
+function summaryProgressLabelStyle(accent: string): CSSProperties {
+  return {
+    color: accent,
+    fontSize: "14px",
+    lineHeight: "18px",
+    fontWeight: 600,
+  };
+}
+
+const videoPreviewSurfaceStyle = {
+  position: "relative",
+  width: "100%",
+  height: "100%",
+  minHeight: "100px",
+  overflow: "hidden",
+  background: "#0f172a",
+} satisfies CSSProperties;
+
+const videoPreviewImageStyle = {
+  width: "100%",
+  height: "100%",
+  minHeight: "112px",
+  display: "block",
+  objectFit: "cover",
+} satisfies CSSProperties;
+
+const videoPreviewOverlayStyle = {
+  position: "absolute",
+  inset: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  paddingBottom: "10px",
+  background:
+    "linear-gradient(180deg, rgba(15,23,42,0.08) 0%, rgba(15,23,42,0.24) 100%)",
+} satisfies CSSProperties;
+
+const videoPreviewPlayButtonStyle = {
+  width: "42px",
+  height: "42px",
+  borderRadius: "999px",
+  background: "rgba(255,255,255,0.9)",
+  boxShadow: "0 8px 18px rgba(15, 23, 42, 0.16)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  transform: "translateY(-4px)",
+} satisfies CSSProperties;
+
+const videoPreviewPlayIconStyle = {
+  width: 0,
+  height: 0,
+  borderTop: "6px solid transparent",
+  borderBottom: "6px solid transparent",
+  borderLeft: `10px solid ${v4Colors.text}`,
+  marginLeft: "2px",
+} satisfies CSSProperties;
+
+const videoPreviewCaptionStyle = {
+  position: "absolute",
+  inset: "auto 0 0 0",
+  padding: "14px 16px 10px",
+  background:
+    "linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgb(77 77 77 / 78%) 100%)",
+} satisfies CSSProperties;
+
+const videoPreviewCaptionTextStyle = {
+  color: appColors.surface,
+  fontWeight: 600,
+  textShadow: "0 1px 2px rgba(15, 23, 42, 0.24)",
+} satisfies CSSProperties;
+
+const videoPreviewFallbackStyle = {
+  width: "100%",
+  height: "100%",
+  minHeight: "112px",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background:
+    "linear-gradient(180deg, rgba(15,23,42,0.92) 0%, rgba(30,41,59,0.96) 100%)",
+} satisfies CSSProperties;
+
+const workbenchHeaderStyle = {
+  paddingBottom: "4px",
+  borderBottom: `1px solid ${v4Colors.divider}`,
+} satisfies CSSProperties;
+
+const scanSummaryStyle = {
+  padding: "12px 14px",
+  borderRadius: "12px",
+  background: v4Colors.primarySoft,
+  border: `1px solid ${v4Colors.cardBorder}`,
+} satisfies CSSProperties;
+
+const emptyStateInnerStyle = {
+  width: "100%",
+  maxWidth: "540px",
+  padding: "28px 24px",
+  borderRadius: "16px",
+  border: `1px dashed ${v4Colors.cardBorder}`,
+  background: appColors.surface,
+} satisfies CSSProperties;
+
+const recommendationRowStyle = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "16px",
+  padding: "12px 16px",
+  borderRadius: "12px",
+  border: `1px solid ${v4Colors.cardBorder}`,
+  background: v4Colors.cardBg,
+} satisfies CSSProperties;
+
+const recommendationMainStyle = {
+  minWidth: 0,
+  display: "grid",
+  gap: "6px",
+} satisfies CSSProperties;
+
+const recommendationMetaListStyle = {
+  display: "flex",
+  alignItems: "center",
+  flexWrap: "wrap",
+  gap: "6px",
+} satisfies CSSProperties;
+
+const recommendationActionWrapStyle = {
+  flexShrink: 0,
+} satisfies CSSProperties;
+
+const recommendationStatusTextStyle = {
+  minHeight: "20px",
+} satisfies CSSProperties;
+
+function recommendationToneDotStyle(tone: RecommendationTone): CSSProperties {
+  const color =
+    tone === "success"
+      ? v4Colors.success
+      : tone === "info"
+        ? v4Colors.info
+        : v4Colors.warning;
+  return {
+    width: "8px",
+    height: "8px",
+    borderRadius: "999px",
+    background: color,
+    flexShrink: 0,
+  };
+}
+
+function tabButtonStyle(active: boolean): CSSProperties {
+  return {
+    appearance: "none",
+    border: "none",
+    background: active ? "#ffffff" : "transparent",
+    color: active ? "#005bd3" : v4Colors.textMuted,
+    borderRadius: "999px",
+    padding: "8px 14px",
+    fontSize: "13px",
+    fontWeight: 600,
+    cursor: "pointer",
+    fontFamily: "inherit",
+    boxShadow: active ? "0 8px 20px rgba(15, 23, 42, 0.12)" : "none",
+    transition: "all 0.18s ease",
+  };
+}

--- a/app/routes/app.translate-v4-mvp/route.tsx
+++ b/app/routes/app.translate-v4-mvp/route.tsx
@@ -603,7 +603,6 @@ export default function TranslateV4MvpRoute() {
 
     let cancelled = false;
     void (async () => {
-      const next: Record<string, number | null> = {};
       for (const item of recommendations) {
         try {
           const res = await fetch("/api/translate-v4/estimate", {
@@ -621,13 +620,18 @@ export default function TranslateV4MvpRoute() {
             ok?: boolean;
             estimate?: { estimatedCredits?: number | null };
           }>(res);
-          next[item.id] = data.ok ? (data.estimate?.estimatedCredits ?? null) : null;
+          if (cancelled) return;
+          setRecommendationEstimates((current) => ({
+            ...current,
+            [item.id]: data.ok ? (data.estimate?.estimatedCredits ?? null) : null,
+          }));
         } catch {
-          next[item.id] = null;
+          if (cancelled) return;
+          setRecommendationEstimates((current) => ({
+            ...current,
+            [item.id]: null,
+          }));
         }
-      }
-      if (!cancelled) {
-        setRecommendationEstimates(next);
       }
     })();
 
@@ -838,7 +842,10 @@ export default function TranslateV4MvpRoute() {
       return;
     }
 
-    const estimatedCredits = recommendationEstimates[item.id] ?? null;
+    const cachedCredits = recommendationEstimates[item.id];
+    const hasCachedCredits =
+      typeof cachedCredits === "number" && Number.isFinite(cachedCredits);
+
     setCreateConfirmConfig({
       recommendationId: item.id,
       targets: item.targets,
@@ -848,22 +855,121 @@ export default function TranslateV4MvpRoute() {
       isHandle: false,
       includeLiquid: false,
       estimate: {
-        estimatedCredits,
-        remainingCredits: remainingCredits ?? 0,
+        estimatedCredits: hasCachedCredits ? cachedCredits : null,
+        remainingCredits,
         isUpperBound: true,
         needsMoreCredits:
-          estimatedCredits != null &&
-          remainingCredits != null &&
-          estimatedCredits > remainingCredits,
-        loading: false,
-        loaded: true,
+          hasCachedCredits && cachedCredits > remainingCredits,
+        loading: !hasCachedCredits,
+        loaded: hasCachedCredits,
       },
     });
+
+    if (hasCachedCredits) return;
+
+    try {
+      const res = await fetch("/api/translate-v4/estimate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          modules: item.modules,
+          targets: item.targets,
+          isCover: false,
+          includeLiquid: false,
+          untranslatedRatioByLocale,
+        }),
+      });
+      const data = await readJsonResponse<{
+        ok?: boolean;
+        estimate?: {
+          estimatedCredits?: number | null;
+          remainingCredits?: number;
+          isUpperBound?: boolean;
+          needsMoreCredits?: boolean;
+        };
+      }>(res);
+      const estimatedCredits = data.ok
+        ? (data.estimate?.estimatedCredits ?? null)
+        : null;
+
+      setRecommendationEstimates((current) => ({
+        ...current,
+        [item.id]: estimatedCredits,
+      }));
+
+      setCreateConfirmConfig((current) => {
+        if (!current || current.recommendationId !== item.id) return current;
+        return {
+          ...current,
+          estimate: {
+            estimatedCredits,
+            remainingCredits:
+              data.estimate?.remainingCredits ?? current.estimate?.remainingCredits ?? remainingCredits,
+            isUpperBound: data.estimate?.isUpperBound ?? true,
+            needsMoreCredits:
+              data.estimate?.needsMoreCredits ??
+              (estimatedCredits != null && estimatedCredits > remainingCredits),
+            loading: false,
+            loaded: true,
+          },
+        };
+      });
+    } catch (err) {
+      console.error("[translate-v4-mvp] confirm estimate failed:", err);
+      setCreateConfirmConfig((current) => {
+        if (!current || current.recommendationId !== item.id) return current;
+        return {
+          ...current,
+          estimate: {
+            estimatedCredits: null,
+            remainingCredits: current.estimate?.remainingCredits ?? remainingCredits,
+            isUpperBound: true,
+            needsMoreCredits: false,
+            loading: false,
+            loaded: true,
+          },
+        };
+      });
+    }
   }, [
     createQuotaGatePending,
     recommendationEstimates,
     remainingCredits,
     t,
+    untranslatedRatioByLocale,
+  ]);
+
+  useEffect(() => {
+    const recommendationId = createConfirmConfig?.recommendationId;
+    if (!recommendationId) return;
+    const cachedCredits = recommendationEstimates[recommendationId];
+    if (typeof cachedCredits !== "number" || !Number.isFinite(cachedCredits)) {
+      return;
+    }
+    if (createConfirmConfig.estimate?.estimatedCredits === cachedCredits) {
+      return;
+    }
+
+    setCreateConfirmConfig((current) => {
+      if (!current || current.recommendationId !== recommendationId) return current;
+      const remaining = current.estimate?.remainingCredits ?? remainingCredits ?? 0;
+      return {
+        ...current,
+        estimate: {
+          estimatedCredits: cachedCredits,
+          remainingCredits: remaining,
+          isUpperBound: true,
+          needsMoreCredits: cachedCredits > remaining,
+          loading: false,
+          loaded: true,
+        },
+      };
+    });
+  }, [
+    createConfirmConfig?.estimate?.estimatedCredits,
+    createConfirmConfig?.recommendationId,
+    recommendationEstimates,
+    remainingCredits,
   ]);
 
   const handleCreateConfirm = useCallback(async () => {

--- a/app/routes/app.translate-v4-mvp/route.tsx
+++ b/app/routes/app.translate-v4-mvp/route.tsx
@@ -838,31 +838,6 @@ export default function TranslateV4MvpRoute() {
       return;
     }
 
-    if (remainingCredits > 30_000) {
-      setSubmittingRecommendationIds((current) =>
-        current.includes(item.id)
-          ? current
-          : [...current, item.id],
-      );
-      setCreating(true);
-      try {
-        await createTasksWithConfig({
-          nextTargets: item.targets,
-          nextModules: item.modules,
-          nextAiModel: DEFAULT_AI_MODEL,
-          nextIsCover: false,
-          nextIsHandle: false,
-          nextIncludeLiquid: false,
-        });
-      } finally {
-        setCreating(false);
-        setSubmittingRecommendationIds((current) =>
-          current.filter((id) => id !== item.id),
-        );
-      }
-      return;
-    }
-
     const estimatedCredits = recommendationEstimates[item.id] ?? null;
     setCreateConfirmConfig({
       recommendationId: item.id,
@@ -885,7 +860,6 @@ export default function TranslateV4MvpRoute() {
       },
     });
   }, [
-    createTasksWithConfig,
     createQuotaGatePending,
     recommendationEstimates,
     remainingCredits,

--- a/app/routes/app.translate-v4/components/CreateTaskCard.tsx
+++ b/app/routes/app.translate-v4/components/CreateTaskCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { BlockStack, Button, Checkbox, Select } from "@shopify/polaris";
 import { useTranslation } from "react-i18next";
+import { message } from "~/ui/message";
 import { v4Colors, v4CardStyle } from "../v4Styles";
 import {
   AI_MODEL_OPTIONS,
@@ -63,9 +64,11 @@ export function CreateTaskCard({
   estimate = null,
 }: Props) {
   const { t } = useTranslation();
+  const missingTargetSelection = targets.length === 0;
+  const missingContentSelection = modules.length === 0 && !includeLiquid;
+  const selectionInvalid = missingTargetSelection || missingContentSelection;
   const canCreate =
-    targets.length > 0 &&
-    (modules.length > 0 || includeLiquid) &&
+    !selectionInvalid &&
     !creating &&
     !createDisabled;
   const [advancedOpen, setAdvancedOpen] = useState(advancedDefaultOpen);
@@ -130,9 +133,23 @@ export function CreateTaskCard({
     onModulesChange(allModulesSelected ? [] : allModuleValues);
   };
 
+  const handleInvalidCreateAttempt = () => {
+    const errors: string[] = [];
+    if (missingTargetSelection) {
+      errors.push(t("v4.validation.selectTarget"));
+    }
+    if (missingContentSelection) {
+      errors.push(t("v4.validation.selectModule"));
+    }
+    if (errors.length > 0) {
+      message.warning(errors.join(" "));
+    }
+  };
+
   const submitButton = (
     <div
       style={{
+        position: "relative",
         maxWidth: "100%",
         minWidth: submitPlacement === "footer-center" ? 220 : undefined,
       }}
@@ -147,6 +164,14 @@ export function CreateTaskCard({
       >
         {creating ? t("v4.createTask.creating") : t("v4.createTask.confirmAction")}
       </Button>
+      {selectionInvalid && !creating && !createDisabled ? (
+        <button
+          type="button"
+          aria-label={t("v4.createTask.confirmAction")}
+          onClick={handleInvalidCreateAttempt}
+          style={disabledActionOverlayStyle}
+        />
+      ) : null}
     </div>
   );
 
@@ -517,6 +542,18 @@ const checkboxGridStyle: CSSProperties = {
   display: "grid",
   gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
   gap: 10,
+};
+
+const disabledActionOverlayStyle: CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  width: "100%",
+  height: "100%",
+  border: "none",
+  padding: 0,
+  margin: 0,
+  background: "transparent",
+  cursor: "not-allowed",
 };
 
 function checkboxCardStyle(selected: boolean): CSSProperties {

--- a/app/routes/app.translate-v4/components/TaskQueueSection.tsx
+++ b/app/routes/app.translate-v4/components/TaskQueueSection.tsx
@@ -376,6 +376,9 @@ export function TaskQueueSection({
   spotlightTaskIds = [],
   translateSlotBusy,
   loading = false,
+  historyReturnTo = "/app/translate-v4",
+  emptyStateActionLabel,
+  onEmptyStateAction,
   onBuyCredits,
   onAction,
 }: {
@@ -384,6 +387,9 @@ export function TaskQueueSection({
   translateSlotBusy: boolean;
   /** 首帧骨架：数据到达前不要先闪「暂无任务」空态。 */
   loading?: boolean;
+  historyReturnTo?: string;
+  emptyStateActionLabel?: string;
+  onEmptyStateAction?: () => void;
   onBuyCredits: (job: TranslationJobProgressSummary) => void;
   onAction: Props["onAction"];
 }) {
@@ -423,7 +429,11 @@ export function TaskQueueSection({
         <div style={{ display: "flex", alignItems: "center", gap: 12, minWidth: 0, flexWrap: "wrap", justifyContent: "flex-end" }}>
           <button
             type="button"
-            onClick={() => navigate("/app/translate-v4-history")}
+            onClick={() =>
+              navigate(
+                `/app/translate-v4-history?returnTo=${encodeURIComponent(historyReturnTo)}`,
+              )
+            }
             style={historyEntryButtonStyle}
           >
             {t("v4.tasks.openHistory", { count: historyJobs.length })}
@@ -504,6 +514,13 @@ export function TaskQueueSection({
             <Text as="p" variant="bodyMd" tone="subdued">
               {t("v4.tasks.noCurrentDesc")}
             </Text>
+            {emptyStateActionLabel && onEmptyStateAction ? (
+              <div style={{ marginTop: 8 }}>
+                <Button variant="primary" onClick={onEmptyStateAction}>
+                  {emptyStateActionLabel}
+                </Button>
+              </div>
+            ) : null}
           </div>
         </div>
       ) : (

--- a/app/routes/app.translate-v4/jobFilters.ts
+++ b/app/routes/app.translate-v4/jobFilters.ts
@@ -7,3 +7,12 @@ export function isCurrentV4Job(job: TranslationJobProgressSummary): boolean {
 export function isHistoryV4Job(job: TranslationJobProgressSummary): boolean {
   return job.isTerminal && job.status !== "PAUSED" && job.status !== "FAILED";
 }
+
+export function shouldPollV4Job(job: TranslationJobProgressSummary): boolean {
+  return (
+    !job.isTerminal &&
+    job.status !== "PAUSED" &&
+    job.status !== "FAILED" &&
+    job.status !== "CANCELLED"
+  );
+}

--- a/app/routes/app.translate-v4/useCreateTaskEstimate.ts
+++ b/app/routes/app.translate-v4/useCreateTaskEstimate.ts
@@ -7,6 +7,7 @@ export type CreateTaskEstimateView = {
   isUpperBound: boolean;
   needsMoreCredits: boolean;
   loading: boolean;
+  loaded: boolean;
 };
 
 const EMPTY_ESTIMATE: CreateTaskEstimateView = {
@@ -15,6 +16,7 @@ const EMPTY_ESTIMATE: CreateTaskEstimateView = {
   isUpperBound: true,
   needsMoreCredits: false,
   loading: false,
+  loaded: false,
 };
 
 /** 展示用额度简写：1200 → 1K，1_500_000 → 1.5M */
@@ -69,6 +71,7 @@ export function useCreateTaskEstimate(args: {
         estimatedCredits: null,
         remainingCredits: remainingCredits ?? prev.remainingCredits,
         loading: false,
+        loaded: false,
         needsMoreCredits: false,
         isUpperBound: true,
       }));
@@ -76,7 +79,7 @@ export function useCreateTaskEstimate(args: {
     }
 
     let cancelled = false;
-    setEstimate((prev) => ({ ...prev, loading: true }));
+    setEstimate((prev) => ({ ...prev, loading: true, loaded: false }));
     const timer = window.setTimeout(() => {
       void (async () => {
         try {
@@ -95,7 +98,7 @@ export function useCreateTaskEstimate(args: {
           const data = text.trim()
             ? (JSON.parse(text) as {
                 ok?: boolean;
-                estimate?: Omit<CreateTaskEstimateView, "loading">;
+                estimate?: Omit<CreateTaskEstimateView, "loading" | "loaded">;
               })
             : null;
           if (cancelled) return;
@@ -106,12 +109,14 @@ export function useCreateTaskEstimate(args: {
               isUpperBound: data.estimate.isUpperBound ?? true,
               needsMoreCredits: data.estimate.needsMoreCredits,
               loading: false,
+              loaded: true,
             });
           } else {
             setEstimate((prev) => ({
               ...prev,
               estimatedCredits: null,
               loading: false,
+              loaded: true,
             }));
           }
         } catch (err) {
@@ -121,6 +126,7 @@ export function useCreateTaskEstimate(args: {
               ...prev,
               estimatedCredits: null,
               loading: false,
+              loaded: true,
             }));
           }
         }

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -8,6 +8,7 @@ import {
   Link,
   Outlet,
   useLoaderData,
+  useLocation,
   useRouteError,
 } from "@remix-run/react";
 import { boundary } from "@shopify/shopify-app-remix/server";
@@ -37,7 +38,7 @@ import { useTranslation } from "react-i18next";
 import { useIdleReady } from "~/hooks/useIdleReady";
 
 import { ConfigProvider } from "antd";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import type { Dispatch } from "@reduxjs/toolkit";
 import {
   setChars,
@@ -65,6 +66,11 @@ import {
   OPEN_CREDITS_PURCHASE_MODAL_EVENT,
   type CreditsPurchaseModalContext,
 } from "~/utils/creditsPurchaseModal";
+import { refreshBillingBootstrap } from "~/utils/billingBootstrap";
+import {
+  parseBillingReturn,
+  stripBillingReturnParams,
+} from "~/utils/billingReturn";
 
 export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
@@ -517,6 +523,8 @@ export default function App() {
 
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const location = useLocation();
+  const totalChars = useSelector((state: any) => state.userConfig.totalChars);
 
   useEffect(() => {
     if (isPerfDebugEnabled()) {
@@ -598,6 +606,34 @@ export default function App() {
       );
     };
   }, [isClient]);
+
+  useEffect(() => {
+    if (!isClient) return;
+
+    const billingReturn = parseBillingReturn(location.search);
+    if (!billingReturn) return;
+
+    const cleanedPath = stripBillingReturnParams(
+      `${location.pathname}${location.search}${location.hash}`,
+    );
+    window.history.replaceState({}, "", cleanedPath);
+
+    if (billingReturn.kind !== "credits") {
+      return;
+    }
+
+    void refreshBillingBootstrap(
+      dispatch,
+      billingReturn.previousTotalChars ?? totalChars,
+    );
+  }, [
+    dispatch,
+    isClient,
+    location.hash,
+    location.pathname,
+    location.search,
+    totalChars,
+  ]);
 
   return (
     <AppProvider isEmbeddedApp apiKey={apiKey}>

--- a/app/styles.css
+++ b/app/styles.css
@@ -433,12 +433,20 @@ body {
    ========================================================================= */
 
 .v4-page {
-  --v4-accent-primary: #5b4bd6;
-  --v4-accent-primary-hover: #4c3bc0;
-  --v4-accent-primary-deep: #2f256f;
-  --v4-accent-primary-soft: rgba(91, 75, 214, 0.1);
-  --v4-accent-primary-muted: rgba(91, 75, 214, 0.14);
-  --v4-ring-track: rgba(91, 75, 214, 0.16);
+  --v4-accent-primary: #6366f1;
+  --v4-accent-primary-hover: #4f46e5;
+  --v4-accent-primary-deep: #4338ca;
+  --v4-accent-primary-soft: rgba(99, 102, 241, 0.12);
+  --v4-accent-primary-muted: rgba(99, 102, 241, 0.08);
+  --v4-ring-track: #eef2ff;
+  /* Polaris Primary 按钮与圆环共用 v4 靛蓝，避免仍走全局 #5467ff */
+  --p-color-bg-fill-brand: var(--v4-accent-primary);
+  --p-color-bg-fill-brand-hover: var(--v4-accent-primary-hover);
+  --p-color-bg-fill-brand-active: var(--v4-accent-primary-deep);
+  --p-color-border-brand: var(--v4-accent-primary);
+  --p-color-border-brand-hover: var(--v4-accent-primary-hover);
+  --p-color-text-brand: var(--v4-accent-primary);
+  --p-color-text-brand-hover: var(--v4-accent-primary-hover);
 }
 
 .v4-page .ant-tabs-ink-bar {

--- a/app/ui/components/AppMetricTile.tsx
+++ b/app/ui/components/AppMetricTile.tsx
@@ -1,0 +1,44 @@
+import type { CSSProperties, ReactNode } from "react";
+import { BlockStack, Text } from "@shopify/polaris";
+import { appColors, appRadius } from "~/ui/tokens";
+
+interface AppMetricTileProps {
+  label: ReactNode;
+  value: ReactNode;
+  /** 数值下方的补充说明，例如同比或口径提示。 */
+  caption?: ReactNode;
+  style?: CSSProperties;
+}
+
+const tileStyle: CSSProperties = {
+  padding: 14,
+  borderRadius: appRadius.lg,
+  border: `1px solid ${appColors.borderSecondary}`,
+  background: appColors.surface,
+};
+
+/** 概览/报告页的单个指标格：小标签在上，大数值在下。 */
+export default function AppMetricTile({
+  label,
+  value,
+  caption,
+  style,
+}: AppMetricTileProps) {
+  return (
+    <div style={{ ...tileStyle, ...style }}>
+      <BlockStack gap="100">
+        <Text as="span" tone="subdued" variant="bodySm">
+          {label}
+        </Text>
+        <Text as="p" variant="headingLg">
+          {value}
+        </Text>
+        {caption ? (
+          <Text as="span" tone="subdued" variant="bodySm">
+            {caption}
+          </Text>
+        ) : null}
+      </BlockStack>
+    </div>
+  );
+}

--- a/app/ui/components/AppMobileListCard.tsx
+++ b/app/ui/components/AppMobileListCard.tsx
@@ -1,0 +1,53 @@
+import type { CSSProperties, ReactNode } from "react";
+import { BlockStack, InlineStack, Text } from "@shopify/polaris";
+import { appColors, appRadius } from "~/ui/tokens";
+
+export interface AppMobileListCardRow {
+  key: string;
+  label: ReactNode;
+  value: ReactNode;
+}
+
+interface AppMobileListCardProps {
+  title: ReactNode;
+  rows?: AppMobileListCardRow[];
+  /** 卡片底部的操作区，通常是一到两个按钮。 */
+  actions?: ReactNode;
+  style?: CSSProperties;
+}
+
+const cardStyle: CSSProperties = {
+  padding: 14,
+  borderRadius: appRadius.lg,
+  border: `1px solid ${appColors.borderSecondary}`,
+  background: appColors.surface,
+};
+
+/**
+ * 窄屏下替代表格行的卡片。标签文案由调用方传入，便于走 i18n。
+ */
+export default function AppMobileListCard({
+  title,
+  rows = [],
+  actions,
+  style,
+}: AppMobileListCardProps) {
+  return (
+    <div style={{ ...cardStyle, ...style }}>
+      <BlockStack gap="200">
+        <Text as="h4" variant="headingSm">
+          {title}
+        </Text>
+        {rows.map((row) => (
+          <InlineStack key={row.key} align="space-between" blockAlign="center">
+            <Text as="span" variant="bodySm">
+              {row.label}
+            </Text>
+            {row.value}
+          </InlineStack>
+        ))}
+        {actions ? <InlineStack gap="200">{actions}</InlineStack> : null}
+      </BlockStack>
+    </div>
+  );
+}

--- a/app/ui/components/AppPill.tsx
+++ b/app/ui/components/AppPill.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties, ReactNode } from "react";
+import { appAccents, appColors, appFontSizes, appRadius } from "~/ui/tokens";
+
+export type AppPillTone = "neutral" | "info" | "success" | "warning" | "critical";
+
+interface AppPillProps {
+  children: ReactNode;
+  tone?: AppPillTone;
+  style?: CSSProperties;
+}
+
+const toneStyles: Record<AppPillTone, CSSProperties> = {
+  neutral: {
+    border: `1px solid ${appColors.borderSecondary}`,
+    background: appColors.surface,
+    color: appColors.textSecondary,
+  },
+  info: {
+    border: "1px solid transparent",
+    background: appAccents.primarySoft,
+    color: appAccents.primary,
+  },
+  success: {
+    border: "1px solid transparent",
+    background: appAccents.growthSoft,
+    color: appAccents.growth,
+  },
+  warning: {
+    border: "1px solid transparent",
+    background: appAccents.utilitySoft,
+    color: appAccents.utility,
+  },
+  critical: {
+    border: "1px solid transparent",
+    background: appAccents.criticalSoft,
+    color: appAccents.critical,
+  },
+};
+
+const basePillStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  minHeight: 28,
+  padding: "0 10px",
+  borderRadius: appRadius.md,
+  fontSize: appFontSizes.caption,
+  fontWeight: 600,
+  whiteSpace: "nowrap",
+};
+
+/**
+ * 轻量标签：用于展示只读的元信息（覆盖率、待译条目、额度、耗时等）。
+ * 需要表达资源状态时用 Polaris `Badge` 或 `AppStatusBadge`，不要用这个。
+ */
+export default function AppPill({ children, tone = "neutral", style }: AppPillProps) {
+  return (
+    <span style={{ ...basePillStyle, ...toneStyles[tone], ...style }}>{children}</span>
+  );
+}

--- a/app/ui/components/AppProgressRing.tsx
+++ b/app/ui/components/AppProgressRing.tsx
@@ -1,0 +1,125 @@
+import type { CSSProperties, ReactNode } from "react";
+import { appAccents, appColors } from "~/ui/tokens";
+
+const ringPrimary = `var(--v4-accent-primary, ${appAccents.primary})`;
+const ringTrack = `var(--v4-ring-track, ${appAccents.primarySoft})`;
+
+export interface AppProgressRingProps {
+  percent: number | null;
+  size?: number;
+  strokeWidth?: number;
+  /** 圆心主文案，默认显示百分比 */
+  center?: ReactNode;
+  /** 圆心副文案（如「整体覆盖率」） */
+  sublabel?: ReactNode;
+  loading?: boolean;
+  /** 100% 时使用 success 色而非 primary */
+  successAtFull?: boolean;
+  style?: CSSProperties;
+}
+
+/**
+ * SVG 圆环进度（圆角端点），与 UI demo / MVP 覆盖率环同一视觉语言。
+ * 在 `.v4-page` 内自动跟随 v4 靛蓝 token。
+ */
+export default function AppProgressRing({
+  percent,
+  size = 132,
+  strokeWidth = 3,
+  center,
+  sublabel,
+  loading = false,
+  successAtFull = false,
+  style,
+}: AppProgressRingProps) {
+  const safePercent =
+    percent == null || loading
+      ? 0
+      : Math.max(0, Math.min(percent, 100));
+  const dash = `${safePercent} 100`;
+  const done = safePercent >= 100;
+  const stroke = done && successAtFull ? appAccents.growth : ringPrimary;
+
+  const centerContent =
+    center ??
+    (loading || percent == null ? "—" : `${Math.round(safePercent)}%`);
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: size,
+        height: size,
+        flexShrink: 0,
+        ...style,
+      }}
+    >
+      <svg
+        viewBox="0 0 36 36"
+        style={{ width: size, height: size, transform: "rotate(-90deg)" }}
+        aria-hidden
+      >
+        <circle
+          cx="18"
+          cy="18"
+          r="15.5"
+          fill="none"
+          stroke={ringTrack}
+          strokeWidth={strokeWidth}
+        />
+        <circle
+          cx="18"
+          cy="18"
+          r="15.5"
+          fill="none"
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+          strokeDasharray={dash}
+          strokeLinecap="round"
+        />
+      </svg>
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          textAlign: "center",
+          padding: "0 8px",
+        }}
+      >
+        <span
+          style={{
+            fontSize: size >= 120 ? 28 : size >= 80 ? 22 : 12,
+            fontWeight: 700,
+            letterSpacing: "-0.03em",
+            lineHeight: 1,
+            color: appColors.text,
+            fontFamily:
+              size < 80
+                ? "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace"
+                : undefined,
+          }}
+        >
+          {centerContent}
+        </span>
+        {sublabel ? (
+          <span
+            style={{
+              fontSize: size >= 120 ? 11 : 10,
+              color: appColors.textSecondary,
+              marginTop: size >= 120 ? 6 : 2,
+              fontWeight: 600,
+              letterSpacing: "-0.01em",
+              lineHeight: 1.25,
+            }}
+          >
+            {sublabel}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/ui/components/AppSectionCard.tsx
+++ b/app/ui/components/AppSectionCard.tsx
@@ -7,6 +7,7 @@ interface AppSectionCardProps {
   extra?: ReactNode;
   children: ReactNode;
   bodyPadding?: string;
+  className?: string;
   style?: CSSProperties;
 }
 
@@ -48,12 +49,14 @@ export default function AppSectionCard({
   extra,
   children,
   bodyPadding = "16px",
+  className,
   style,
 }: AppSectionCardProps) {
   const hasHeader = title || description || extra;
 
   return (
     <Card
+      className={className}
       style={{
         width: "100%",
         border: "1px solid var(--app-color-border-secondary)",

--- a/app/ui/components/index.ts
+++ b/app/ui/components/index.ts
@@ -1,0 +1,16 @@
+/**
+ * 共享 UI 组件出口。新页面优先从这里取组件，而不是在路由目录里重写一份。
+ * 可视化清单见 `/app/ui-library-demo`（仅开发环境可访问）。
+ */
+export { default as AppProgressRing } from "./AppProgressRing";
+export type { AppProgressRingProps } from "./AppProgressRing";
+export { default as AppButton } from "./AppButton";
+export type { AppButtonProps } from "./AppButton";
+export { default as AppMetricTile } from "./AppMetricTile";
+export { default as AppMobileListCard } from "./AppMobileListCard";
+export type { AppMobileListCardRow } from "./AppMobileListCard";
+export { default as AppPageHeader } from "./AppPageHeader";
+export { default as AppPill } from "./AppPill";
+export type { AppPillTone } from "./AppPill";
+export { default as AppSectionCard } from "./AppSectionCard";
+export { default as AppStatusBadge } from "./AppStatusBadge";

--- a/app/ui/tokens.ts
+++ b/app/ui/tokens.ts
@@ -1,0 +1,75 @@
+/**
+ * TS 侧唯一的设计 token 出口。值全部指向 `app/styles.css` 里定义的 `--app-*`
+ * CSS 变量，所以 `app/routes/app.ui-library-demo` 的配置台可以在预览容器上
+ * 覆盖同名变量做实时换肤，而无需改动组件代码。
+ *
+ * 写 inline style 时用这里的常量，不要直接写十六进制色值或魔法 px。
+ */
+
+export const appColors = {
+  bg: "var(--app-color-bg)",
+  surface: "var(--app-color-surface)",
+  surfaceSecondary: "var(--app-color-surface-secondary)",
+  surfaceHover: "var(--app-color-surface-hover)",
+  surfaceSelected: "var(--app-color-surface-selected)",
+  surfaceInfo: "var(--app-color-surface-info)",
+  surfaceSuccess: "var(--app-color-surface-success)",
+  surfaceCaution: "var(--app-color-surface-caution)",
+  surfaceCritical: "var(--app-color-surface-critical)",
+  border: "var(--app-color-border)",
+  borderSecondary: "var(--app-color-border-secondary)",
+  text: "var(--app-color-text)",
+  textSecondary: "var(--app-color-text-secondary)",
+  textTertiary: "var(--app-color-text-tertiary)",
+} as const;
+
+export const appAccents = {
+  primary: "var(--app-accent-primary)",
+  primaryHover: "var(--app-accent-primary-hover)",
+  primaryDeep: "var(--app-accent-primary-deep)",
+  primarySoft: "var(--app-accent-primary-soft)",
+  primaryMuted: "var(--app-accent-primary-muted)",
+  onFill: "var(--app-color-brand-on-fill)",
+  growth: "var(--app-accent-growth)",
+  growthSoft: "var(--app-accent-growth-soft)",
+  utility: "var(--app-accent-utility)",
+  utilitySoft: "var(--app-accent-utility-soft)",
+  critical: "var(--app-accent-critical)",
+  criticalSoft: "var(--app-accent-critical-soft)",
+} as const;
+
+export const appFontSizes = {
+  body: "var(--app-font-size-body)",
+  bodySmall: "var(--app-font-size-body-small)",
+  caption: "var(--app-font-size-caption)",
+  micro: "var(--app-font-size-micro)",
+} as const;
+
+export const appSpace = {
+  s100: "var(--app-space-100)",
+  s200: "var(--app-space-200)",
+  s300: "var(--app-space-300)",
+  s400: "var(--app-space-400)",
+  s500: "var(--app-space-500)",
+  s600: "var(--app-space-600)",
+} as const;
+
+export const appRadius = {
+  sm: "var(--app-radius-sm)",
+  md: "var(--app-radius-md)",
+  lg: "var(--app-radius-lg)",
+} as const;
+
+export const appShadows = {
+  card: "var(--app-shadow-card)",
+  cardStrong: "var(--app-shadow-card-strong)",
+} as const;
+
+export const appTokens = {
+  color: appColors,
+  accent: appAccents,
+  fontSize: appFontSizes,
+  space: appSpace,
+  radius: appRadius,
+  shadow: appShadows,
+} as const;

--- a/app/utils/billingBootstrap.ts
+++ b/app/utils/billingBootstrap.ts
@@ -1,0 +1,55 @@
+import type { Dispatch } from "@reduxjs/toolkit";
+import {
+  setChars,
+  setIsNew,
+  setPlan,
+  setTotalChars,
+  setTrialCredits,
+  setUpdateTime,
+} from "~/store/modules/userConfig";
+import type { AppBootstrapData } from "~/server/appBootstrap.server";
+
+export async function refreshBillingBootstrap(
+  dispatch: Dispatch,
+  previousTotalChars?: number,
+): Promise<void> {
+  const retryDelaysMs = [0, 600, 1200, 2000, 3000];
+
+  for (const delayMs of retryDelaysMs) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+
+    try {
+      const res = await fetch("/api/app-bootstrap");
+      const data = (await res.json()) as {
+        ok?: boolean;
+        bootstrap?: AppBootstrapData;
+      };
+      if (!data.ok || !data.bootstrap) continue;
+
+      const bootstrap = data.bootstrap;
+      dispatch(setPlan({ plan: bootstrap.plan }));
+      dispatch(setChars({ chars: bootstrap.chars }));
+      dispatch(setTotalChars({ totalChars: bootstrap.totalChars }));
+      dispatch(setTrialCredits({ trialCredits: bootstrap.trialCredits ?? 0 }));
+      if (bootstrap.updateTime) {
+        dispatch(setUpdateTime({ updateTime: bootstrap.updateTime }));
+      } else {
+        dispatch(setUpdateTime({ updateTime: "" }));
+      }
+      if (bootstrap.isNew !== null && bootstrap.isNew !== undefined) {
+        dispatch(setIsNew({ isNew: bootstrap.isNew }));
+      }
+
+      if (
+        previousTotalChars === undefined ||
+        bootstrap.totalChars !== previousTotalChars
+      ) {
+        return;
+      }
+    } catch {
+      // Billing webhook settlement can lag a little after the hosted confirmation.
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- 从 `feature/translate-v4-mvp` 抽出 **P0 干净切片**：新增 `/app/translate-v4-mvp` + `/app/translate-v4-mvp-custom`，并把 `/app` / `getTranslatePagePath()` 默认指向 MVP。
- 仅带硬依赖：TaskQueue `returnTo` / 空态 CTA、`shouldPollV4Job`、estimate `loaded`、UI tokens/`App*`、billing return 回刷额度。
- **不含**：onboarding 重构、Switcher 大改、ui-library-demo、DB migration。

## Test plan
- [ ] 打开 `/app` 应进入 MVP 工作台
- [ ] 推荐卡建任务 → 二次确认 → 队列可见
- [ ] 「自定义翻译」进入 mvp-custom，可创建任务
- [ ] 任务历史返回应回到 MVP 队列 tab
- [ ] 买积分回跳后额度应刷新（billing return）
- [ ] 旧 `/app/translate-v4` 仍可访问
